### PR TITLE
Make sure gif is resized correctly

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -278,4 +278,34 @@ class Core implements CoreInterface, IteratorAggregate
     {
         return new ArrayIterator($this); // @phpstan-ignore-line
     }
+
+    /**
+     * Show debug info for the current image
+     *
+     * @throws Exception
+     * @return array<string, mixed>
+     */
+    public function __debugInfo(): array
+    {
+        $debug = [];
+
+        foreach ($this->vipsImage->getFields() as &$name) {
+            $value = $this->vipsImage->get($name);
+
+            if (str_ends_with($name, "-data")) {
+                $len = strlen($value);
+                $value = "<$len bytes of binary data>";
+            }
+
+            if (is_array($value)) {
+                $value = implode(", ", $value);
+            } else {
+                $value = (string) $value;
+            }
+
+            $debug[$name] = $value;
+        }
+
+        return $debug;
+    }
 }

--- a/src/Core.php
+++ b/src/Core.php
@@ -289,7 +289,7 @@ class Core implements CoreInterface, IteratorAggregate
     {
         $debug = [];
 
-        foreach ($this->vipsImage->getFields() as &$name) {
+        foreach ($this->vipsImage->getFields() as $name) {
             $value = $this->vipsImage->get($name);
 
             if (str_ends_with($name, "-data")) {

--- a/tests/Unit/Modifiers/ResizeModifierTest.php
+++ b/tests/Unit/Modifiers/ResizeModifierTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(\Intervention\Image\Drivers\Vips\Modifiers\ResizeModifier::class)]
 final class ResizeModifierTest extends BaseTestCase
 {
-    public function testModify(): void
+    public function testResize(): void
     {
         $image = $this->readTestImage('blocks.png');
         $this->assertEquals(640, $image->width());
@@ -21,5 +21,15 @@ final class ResizeModifierTest extends BaseTestCase
         $this->assertEquals(200, $image->width());
         $this->assertEquals(100, $image->height());
         $this->assertColor(255, 0, 0, 255, $image->pickColor(150, 70));
+    }
+
+    public function testResizeAnimated(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $this->assertEquals(20, $image->width());
+        $this->assertEquals(15, $image->height());
+        $image->modify(new ResizeModifier(10, 10));
+        $this->assertEquals(10, $image->width());
+        $this->assertEquals(10, $image->height());
     }
 }


### PR DESCRIPTION
- added debug info for core
- added resize test for gif

Example of debug info for `Core`:
```
object(Intervention\Image\Drivers\Vips\Core)#293 (21) {
  ["width"]=>
  string(2) "10"
  ["height"]=>
  string(2) "80"
  ["bands"]=>
  string(1) "4"
  ["format"]=>
  string(5) "uchar"
  ["coding"]=>
  string(4) "none"
  ["interpretation"]=>
  string(4) "srgb"
  ["xoffset"]=>
  string(1) "0"
  ["yoffset"]=>
  string(1) "0"
  ["xres"]=>
  string(1) "1"
  ["yres"]=>
  string(1) "1"
  ["filename"]=>
  string(8) "temp-100"
  ["vips-loader"]=>
  string(7) "gifload"
  ["n-pages"]=>
  string(1) "8"
  ["loop"]=>
  string(1) "3"
  ["delay"]=>
  string(38) "200, 200, 200, 200, 200, 200, 200, 200"
  ["background"]=>
  string(12) "185, 134, 36"
  ["gif-palette"]=>
  string(350) "-10269895, -16668929, -10531006, -10661563, -11967635, -15885338, -11837078, -14383431, -10400708, -10857653, -13534818, -13338728, -13861208, -16407818, -16277261, -11053486, -14971189, -15036210, -12424579, -16538116, -12620414, -13012081, -16211726, -16081171, -16473096, -12294025, -15167280, -12098190, -10465728, -13208429, -14644799, -14840634"
  ["bits-per-sample"]=>
  string(1) "5"
  ["palette"]=>
  string(1) "1"
  ["interlaced"]=>
  string(1) "1"
  ["page-height"]=>
  string(2) "10"
}
```