### PR TITLE
Fix bug in Driver::createAnimation()

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ $encoded->save('images/example.jpg');
 | - | - |
 | ImageManager::read() | ✅ |
 | ImageManager::create() | ✅ |
-| ImageManager::animate() | ❌ |
+| ImageManager::animate() | ✅ |
 
 
 ## Contributing

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,15 @@ $encoded = $image->toJpg();
 $encoded->save('images/example.jpg');
 ```
 
+## Feature Status
+
+| Feature | Status |
+| - | - |
+| ImageManager::read() | ✅ |
+| ImageManager::create() | ✅ |
+| ImageManager::animate() | ❌ |
+
+
 ## Contributing
 Check out the [documentation](https://github.com/Intervention/image/blob/develop/CONTRIBUTING.md)
 ```bash

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -98,7 +98,7 @@ class Driver extends AbstractDriver
                 $delay = [];
 
                 foreach ($this->frames as $frame) {
-                    $delay = array_merge($delay, $frame->native()->get('delay'));
+                    $delay[] = intval($frame->delay() * 1000);
                     $frames[] = $frame->native();
                 }
 


### PR DESCRIPTION
I noticed an error when creating animation from PNG files like this:


```php
ImageManager::withDriver(Vips\Driver::class)
    ->animate(function ($animation) {
        $animation->add('frame01.png', .5);
        $animation->add('frame02.png', .5);
        $animation->add('frame03.png', .5);
    })->setLoops(2)
      ->toGif();
```

`Fatal error: Uncaught Jcupitt\Vips\Exception: libvips error: pngload: no property named 'n' pngload: no property named 'n' pngload: no property named 'n' vips_image_get: field "delay" not found`

I have noticed that the delay is read from the Vips image. This value does not always seem to be present. I have changed the logic and now read the delay directly from the frame and convert it accordingly for vips.