### PR TITLE
fix(encoders): version-gate ForeignKeep::ALL for GAINMAP (libvips 8.18)

### DIFF
--- a/src/Encoders/AvifEncoder.php
+++ b/src/Encoders/AvifEncoder.php
@@ -54,7 +54,10 @@ class AvifEncoder extends GenericAvifEncoder implements SpecializedInterface
         $strip = $this->strip || $this->driver()->config()->strip;
 
         if (VipsConfig::atLeast(8, 15)) {
-            $options['keep'] = $strip ? ForeignKeep::ICC : ForeignKeep::ALL;
+            $keepAll = VipsConfig::atLeast(8, 18)
+                ? ForeignKeep::ALL
+                : ForeignKeep::ALL & ~ForeignKeep::GAINMAP;
+            $options['keep'] = $strip ? ForeignKeep::ICC : $keepAll;
         } else {
             $options['strip'] = $strip;
         }

--- a/src/Encoders/HeicEncoder.php
+++ b/src/Encoders/HeicEncoder.php
@@ -54,7 +54,10 @@ class HeicEncoder extends GenericHeicEncoder implements SpecializedInterface
         $strip = $this->strip || $this->driver()->config()->strip;
 
         if (VipsConfig::atLeast(8, 15)) {
-            $options['keep'] = $strip ? ForeignKeep::ICC : ForeignKeep::ALL;
+            $keepAll = VipsConfig::atLeast(8, 18)
+                ? ForeignKeep::ALL
+                : ForeignKeep::ALL & ~ForeignKeep::GAINMAP;
+            $options['keep'] = $strip ? ForeignKeep::ICC : $keepAll;
         } else {
             $options['strip'] = $strip;
         }

--- a/src/Encoders/Jpeg2000Encoder.php
+++ b/src/Encoders/Jpeg2000Encoder.php
@@ -60,7 +60,10 @@ class Jpeg2000Encoder extends GenericJpeg2000Encoder implements SpecializedInter
         $strip = $this->strip || $this->driver()->config()->strip;
 
         if (VipsConfig::atLeast(8, 15)) {
-            $options['keep'] = $strip ? ForeignKeep::ICC : ForeignKeep::ALL;
+            $keepAll = VipsConfig::atLeast(8, 18)
+                ? ForeignKeep::ALL
+                : ForeignKeep::ALL & ~ForeignKeep::GAINMAP;
+            $options['keep'] = $strip ? ForeignKeep::ICC : $keepAll;
         } else {
             $options['strip'] = $strip;
         }

--- a/src/Encoders/JpegEncoder.php
+++ b/src/Encoders/JpegEncoder.php
@@ -62,7 +62,10 @@ class JpegEncoder extends GenericJpegEncoder implements SpecializedInterface
         $strip = $this->strip || $this->driver()->config()->strip;
 
         if (VipsConfig::atLeast(8, 15)) {
-            $options['keep'] = $strip ? ForeignKeep::ICC : ForeignKeep::ALL;
+            $keepAll = VipsConfig::atLeast(8, 18)
+                ? ForeignKeep::ALL
+                : ForeignKeep::ALL & ~ForeignKeep::GAINMAP;
+            $options['keep'] = $strip ? ForeignKeep::ICC : $keepAll;
         } else {
             $options['strip'] = $strip;
         }

--- a/src/Encoders/TiffEncoder.php
+++ b/src/Encoders/TiffEncoder.php
@@ -54,7 +54,10 @@ class TiffEncoder extends GenericTiffEncoder implements SpecializedInterface
         $strip = $this->strip || $this->driver()->config()->strip;
 
         if (VipsConfig::atLeast(8, 15)) {
-            $options['keep'] = $strip ? ForeignKeep::ICC : ForeignKeep::ALL;
+            $keepAll = VipsConfig::atLeast(8, 18)
+                ? ForeignKeep::ALL
+                : ForeignKeep::ALL & ~ForeignKeep::GAINMAP;
+            $options['keep'] = $strip ? ForeignKeep::ICC : $keepAll;
         } else {
             $options['strip'] = true;
         }

--- a/src/Encoders/WebpEncoder.php
+++ b/src/Encoders/WebpEncoder.php
@@ -54,7 +54,10 @@ class WebpEncoder extends GenericWebpEncoder implements SpecializedInterface
         $strip = $this->strip || $this->driver()->config()->strip;
 
         if (VipsConfig::atLeast(8, 15)) {
-            $options['keep'] = $strip ? ForeignKeep::ICC : ForeignKeep::ALL;
+            $keepAll = VipsConfig::atLeast(8, 18)
+                ? ForeignKeep::ALL
+                : ForeignKeep::ALL & ~ForeignKeep::GAINMAP;
+            $options['keep'] = $strip ? ForeignKeep::ICC : $keepAll;
         } else {
             $options['strip'] = $strip;
         }


### PR DESCRIPTION
On libvips 8.15-8.17, every encode emits `GLib-GObject-CRITICAL: value "(VIPS_FOREIGN_KEEP_EXIF | ... | 32)" of type 'VipsForeignKeep' is invalid or out of range` to stderr. The 32 bit is `GAINMAP`, which only landed in libvips 8.18.0 (commit [80924795](https://github.com/libvips/libvips/commit/80924795), [#4708](https://github.com/libvips/libvips/pull/4708), between v8.18.0-alpha1 and v8.18.0).

Bytes are still produced correctly, only stderr gets spammed.

So: on libvips >= 8.18 use `ForeignKeep::ALL = 63` as before, on 8.15-8.17 use `ForeignKeep::ALL & ~ForeignKeep::GAINMAP = 31` (= EXIF|XMP|IPTC|ICC|OTHER). The bitmask form rather than literal 31 keeps working if a future libvips extends ALL again.

Same change in all 6 encoders that use `ForeignKeep::ALL`: Jpeg, Webp, Avif, Heic, Tiff, Jpeg2000.

Bench: no measurable delta on libvips 8.18.1, since the new branch never fires there.

Possible follow-up (out of scope here): extend `.github/workflows/run-tests.yml`'s libvips matrix to include 8.15.x or 8.17.x so the < 8.18 branch is covered by CI. Right now the matrix only covers 8.18.1.

Two unrelated things I noticed but did not modify:
- `tests/Unit/Encoders/Jpeg200EncoderTest.php` filename typo (missing trailing `0`).
- `TiffEncoder::options()` line 59 passes `$options['strip'] = true` literal where the other 5 encoders pass `$strip`. Probably a typo.
