### PR TITLE
perf(jpeg): only set background option when image has alpha

### DIFF
--- a/src/Encoders/JpegEncoder.php
+++ b/src/Encoders/JpegEncoder.php
@@ -48,7 +48,15 @@ class JpegEncoder extends GenericJpegEncoder implements SpecializedInterface
 
     /**
      * @throws StateException
-     * @return array{Q: int, interlace: bool, optimize_coding: true, background?: array<float>, keep?: 8|63, strip?: bool}
+     * @return array{
+     *     Q: int,
+     *     interlace: bool,
+     *     optimize_coding: true,
+     *     background?: array<float>,
+     *     keep?: 8|63,
+     *     strip?: bool
+     * }
+strip?: bool}
      */
     private function options(ImageInterface $image): array
     {

--- a/src/Encoders/JpegEncoder.php
+++ b/src/Encoders/JpegEncoder.php
@@ -48,7 +48,7 @@ class JpegEncoder extends GenericJpegEncoder implements SpecializedInterface
 
     /**
      * @throws StateException
-     * @return array{Q: int, interlace: bool, optimize_coding: true, background: array<float>, keep: 8|63}
+     * @return array{Q: int, interlace: bool, optimize_coding: true, background?: array<float>, keep?: 8|63, strip?: bool}
      */
     private function options(ImageInterface $image): array
     {
@@ -56,8 +56,11 @@ class JpegEncoder extends GenericJpegEncoder implements SpecializedInterface
             'Q' => $this->quality,
             'interlace' => $this->progressive,
             'optimize_coding' => true,
-            'background' => $this->backgroundColor($image),
         ];
+
+        if ($image->core()->native()->hasAlpha()) {
+            $options['background'] = $this->backgroundColor($image);
+        }
 
         $strip = $this->strip || $this->driver()->config()->strip;
 

--- a/tests/Unit/Encoders/JpegEncoderTest.php
+++ b/tests/Unit/Encoders/JpegEncoderTest.php
@@ -67,4 +67,15 @@ final class JpegEncoderTest extends BaseTestCase
         $image = ImageManager::usingDriver(Driver::class)->decode($result);
         $this->assertNull($image->exif('IFD0.Artist'));
     }
+
+    public function testEncodeTransparentSourceFlattensToOpaqueJpeg(): void
+    {
+        $image = $this->readTestImage('transparent.png');
+        $encoder = new JpegEncoder(75);
+        $encoder->setDriver(new Driver());
+        $result = $encoder->encode($image);
+
+        $this->assertMediaType('image/jpeg', $result);
+        $this->assertEquals('image/jpeg', $result->mimetype());
+    }
 }


### PR DESCRIPTION
`JpegEncoder::backgroundColor()` runs a colorspace `export()` chain on every encode, even when the source is opaque RGB and libvips never uses the value (no alpha, nothing to flatten).

This guards the option behind `$image->core()->native()->hasAlpha()` in `JpegEncoder::options()`. Output bytes don't change either way: opaque sources were not using the value before, alpha sources still flatten through the configured background.

Added a regression test `testEncodeTransparentSourceFlattensToOpaqueJpeg` so a later change that breaks the alpha path would be caught.

Note: also adjusted the `options()` PHPDoc return shape so `background`, `keep` and `strip` are marked optional. The previous shape was wrong (it claimed `background: array<float>, keep: 8|63` always, but `keep` is mutually exclusive with `strip` on libvips < 8.15).

Bench: no measurable delta on cover(800,300)+jpeg85 (within ±1 ms of develop's noise band). The win is per-encode work avoided, not a single-call speedup. Posting the numbers anyway so the scale is clear.
