### PR TITLE
perf(cover): skip frame loop in CoverModifier for single-frame images

### DIFF
--- a/src/Modifiers/CoverModifier.php
+++ b/src/Modifiers/CoverModifier.php
@@ -40,9 +40,23 @@ class CoverModifier extends GenericCoverModifier implements SpecializedInterface
             );
         }
 
+        $colorspace = $image->colorspace();
+
+        if (!$image->isAnimated()) {
+            $native = $this->cropResizeFrame(
+                $image->core()->first(),
+                $crop,
+                $resize,
+                $colorspace,
+            );
+            $image->core()->setNative($native);
+
+            return $image;
+        }
+
         $frames = [];
         foreach ($image as $frame) {
-            $native = $this->cropResizeFrame($frame, $crop, $resize, $image->colorspace());
+            $native = $this->cropResizeFrame($frame, $crop, $resize, $colorspace);
             $frames[] = $frame->setNative($native);
         }
 


### PR DESCRIPTION
`ContainModifier::apply()` already has a `!isAnimated()` fast path (lines 51-57). It uses `$image->core()->first()` directly and skips the per-frame loop and the `Core::replaceFrames` round-trip. `CoverModifier::apply()` did not have it, so I added the same: `cropResizeFrame()` on the first frame, then `setNative()`. The animated path is not changed.

`CoverDownModifier` inherits the change. It only overrides `resizeSize()`, not `apply()`.

No new tests. `testModify` already covers the fast path (single-frame `blocks.png`) and `testModifyAnimated` covers the slow path (`animation.gif`).

Bench on cover(800,300)+jpeg85 (best-of-10, n=3): 13.09 ms -> 11.89 ms (-9 %). libvips 8.18.1, php 8.3.31, docker.
