### PR TITLE
perf: use thumbnail()/thumbnail_buffer() via decoder stash (refs #55)

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -28,7 +28,7 @@ class Core implements CoreInterface, Iterator
 {
     protected int $iteratorIndex = 0;
     protected CollectionInterface $meta;
-    protected PathSource|BufferSource|null $stashedSource = null;
+    protected null|PathSource|BufferSource $stashedSource = null;
 
     /**
      * Create new core instance
@@ -161,7 +161,7 @@ class Core implements CoreInterface, Iterator
      * Return the stashed source ref set by the decoder, or null if none is
      * stashed (either never set, or cleared by a setNative() call).
      */
-    public function stashedSource(): PathSource|BufferSource|null
+    public function stashedSource(): null|PathSource|BufferSource
     {
         return $this->stashedSource;
     }

--- a/src/Core.php
+++ b/src/Core.php
@@ -7,6 +7,8 @@ namespace Intervention\Image\Drivers\Vips;
 use ArrayIterator;
 use Exception;
 use Intervention\Image\Collection;
+use Intervention\Image\Drivers\Vips\Source\BufferSource;
+use Intervention\Image\Drivers\Vips\Source\PathSource;
 use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\ImageException;
 use Intervention\Image\Exceptions\InvalidArgumentException;
@@ -26,6 +28,7 @@ class Core implements CoreInterface, Iterator
 {
     protected int $iteratorIndex = 0;
     protected CollectionInterface $meta;
+    protected PathSource|BufferSource|null $stashedSource = null;
 
     /**
      * Create new core instance
@@ -149,6 +152,28 @@ class Core implements CoreInterface, Iterator
         }
 
         $this->vipsImage = $native;
+        $this->stashedSource = null;
+
+        return $this;
+    }
+
+    /**
+     * Return the stashed source ref set by the decoder, or null if none is
+     * stashed (either never set, or cleared by a setNative() call).
+     */
+    public function stashedSource(): PathSource|BufferSource|null
+    {
+        return $this->stashedSource;
+    }
+
+    /**
+     * Stash a source ref on this core. Set by decoders right after a clean
+     * decode so resize-family modifiers can use libvips' combined
+     * load+resize ops. Cleared automatically the next time setNative() runs.
+     */
+    public function setStashedSource(PathSource|BufferSource $source): self
+    {
+        $this->stashedSource = $source;
 
         return $this;
     }

--- a/src/Decoders/BinaryImageDecoder.php
+++ b/src/Decoders/BinaryImageDecoder.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Decoders;
 
+use Intervention\Image\Drivers\Vips\Core;
+use Intervention\Image\Drivers\Vips\Source\BufferSource;
 use Intervention\Image\Exceptions\DecoderException;
 use Intervention\Image\Exceptions\ImageDecoderException;
 use Intervention\Image\Exceptions\InvalidArgumentException;
@@ -13,6 +15,8 @@ use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Traits\CanDetectImageSources;
 use Jcupitt\Vips;
 use Jcupitt\Vips\Exception as VipsException;
+use Jcupitt\Vips\Image as VipsImage;
+use Jcupitt\Vips\Interpretation;
 use Stringable;
 
 class BinaryImageDecoder extends NativeObjectDecoder
@@ -61,7 +65,15 @@ class BinaryImageDecoder extends NativeObjectDecoder
             throw new ImageDecoderException('Failed to decode unsupported image format from binary data', previous: $e);
         }
 
+        $stashable = $this->isStashableSource($vipsImage);
+
         $image = parent::decode($vipsImage);
+
+        // stash the source ref so resize-family modifiers can swap to thumbnail_buffer()
+        $core = $image->core();
+        if ($stashable && $core instanceof Core) {
+            $core->setStashedSource(new BufferSource($input, $this->stringOptions()));
+        }
 
         // get media type enum from string media type
         $format = Format::tryCreate($image->origin()->mediaType());
@@ -72,5 +84,33 @@ class BinaryImageDecoder extends NativeObjectDecoder
         }
 
         return $image;
+    }
+
+    /**
+     * Return true if the source is in a state where we can safely stash
+     * it for the resize-family modifiers' thumbnail* fast path.
+     *
+     * Skip stashing when the parent decoder will mutate the in-memory
+     * VipsImage in a way that makes the stashed source no longer reflect
+     * the resulting image (auto-orient, BW/GREY16 to SRGB icc_transform).
+     * The bandjoin_const(255) for SRGB-3-band sources is OK to stash
+     * because resize modifiers can re-apply the same alpha if needed.
+     *
+     * @throws StateException
+     */
+    private function isStashableSource(VipsImage $vipsImage): bool
+    {
+        if (in_array($vipsImage->interpretation, [Interpretation::B_W, Interpretation::GREY16], true)) {
+            return false;
+        }
+
+        if (
+            $this->driver()->config()->autoOrientation === true
+            && ($this->exifRotation($vipsImage) ?? 1) > 1
+        ) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Decoders/FilePathImageDecoder.php
+++ b/src/Decoders/FilePathImageDecoder.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Decoders;
 
+use Intervention\Image\Drivers\Vips\Core;
+use Intervention\Image\Drivers\Vips\Source\PathSource;
 use Intervention\Image\Exceptions\DirectoryNotFoundException;
 use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\FileNotFoundException;
@@ -17,6 +19,8 @@ use Intervention\Image\Traits\CanDetectImageSources;
 use Intervention\Image\Traits\CanParseFilePath;
 use Jcupitt\Vips;
 use Jcupitt\Vips\Exception as VipsException;
+use Jcupitt\Vips\Image as VipsImage;
+use Jcupitt\Vips\Interpretation;
 
 class FilePathImageDecoder extends NativeObjectDecoder
 {
@@ -61,7 +65,15 @@ class FilePathImageDecoder extends NativeObjectDecoder
             );
         }
 
+        $stashable = $this->isStashableSource($vipsImage);
+
         $image = parent::decode($vipsImage);
+
+        // stash the source ref so resize-family modifiers can swap to thumbnail()
+        $core = $image->core();
+        if ($stashable && $core instanceof Core) {
+            $core->setStashedSource(new PathSource($path, $this->stringOptions()));
+        }
 
         // set file path on origin
         $image->origin()->setFilePath($path);
@@ -72,5 +84,33 @@ class FilePathImageDecoder extends NativeObjectDecoder
         }
 
         return $image;
+    }
+
+    /**
+     * Return true if the source is in a state where we can safely stash
+     * it for the resize-family modifiers' thumbnail* fast path.
+     *
+     * Skip stashing when the parent decoder will mutate the in-memory
+     * VipsImage in a way that makes the stashed source no longer reflect
+     * the resulting image (auto-orient, BW/GREY16 to SRGB icc_transform).
+     * The bandjoin_const(255) for SRGB-3-band sources is OK to stash
+     * because resize modifiers can re-apply the same alpha if needed.
+     *
+     * @throws StateException
+     */
+    private function isStashableSource(VipsImage $vipsImage): bool
+    {
+        if (in_array($vipsImage->interpretation, [Interpretation::B_W, Interpretation::GREY16], true)) {
+            return false;
+        }
+
+        if (
+            $this->driver()->config()->autoOrientation === true
+            && ($this->exifRotation($vipsImage) ?? 1) > 1
+        ) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Modifiers/CoverModifier.php
+++ b/src/Modifiers/CoverModifier.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Modifiers;
 
+use Intervention\Image\Alignment;
 use Intervention\Image\Drivers\Vips\ColorProcessor;
 use Intervention\Image\Drivers\Vips\Core;
+use Intervention\Image\Drivers\Vips\Source\BufferSource;
+use Intervention\Image\Drivers\Vips\Source\PathSource;
 use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\InvalidArgumentException;
 use Intervention\Image\Exceptions\ModifierException;
@@ -17,6 +20,8 @@ use Intervention\Image\Interfaces\SpecializedInterface;
 use Intervention\Image\Modifiers\CoverModifier as GenericCoverModifier;
 use Jcupitt\Vips\Exception as VipsException;
 use Jcupitt\Vips\Image as VipsImage;
+use Jcupitt\Vips\Interesting;
+use Jcupitt\Vips\Interpretation;
 
 class CoverModifier extends GenericCoverModifier implements SpecializedInterface
 {
@@ -27,6 +32,7 @@ class CoverModifier extends GenericCoverModifier implements SpecializedInterface
      *
      * @throws ModifierException
      * @throws DriverException
+     * @throws InvalidArgumentException
      */
     public function apply(ImageInterface $image): ImageInterface
     {
@@ -41,28 +47,93 @@ class CoverModifier extends GenericCoverModifier implements SpecializedInterface
         }
 
         $colorspace = $image->colorspace();
+        $core = $image->core();
+        $stash = $core instanceof Core ? $core->stashedSource() : null;
+        $isCenter = Alignment::create($this->alignment) === Alignment::CENTER;
 
-        if (!$image->isAnimated()) {
-            $native = $this->cropResizeFrame(
-                $image->core()->first(),
-                $crop,
-                $resize,
-                $colorspace,
-            );
-            $image->core()->setNative($native);
+        // Fastest path: stash-based thumbnail* (combines load + resize + crop)
+        if ($stash !== null && $isCenter && !$image->isAnimated()) {
+            try {
+                $native = $this->normalizeBands(
+                    $this->coverFromStash($stash, $resize, $colorspace)
+                );
+            } catch (VipsException $e) {
+                throw new ModifierException(
+                    'Failed to apply ' . self::class . ', unable to process resizing',
+                    previous: $e
+                );
+            }
+
+            $core->setNative($native);
 
             return $image;
         }
 
+        // Single-frame path: skip the per-frame loop
+        if (!$image->isAnimated()) {
+            $native = $this->cropResizeFrame(
+                $core->first(),
+                $crop,
+                $resize,
+                $colorspace,
+            );
+            $core->setNative($native);
+
+            return $image;
+        }
+
+        // Animated path
         $frames = [];
         foreach ($image as $frame) {
             $native = $this->cropResizeFrame($frame, $crop, $resize, $colorspace);
             $frames[] = $frame->setNative($native);
         }
 
-        $image->core()->setNative(
-            Core::replaceFrames($image->core()->native(), $frames)
+        $core->setNative(
+            Core::replaceFrames($core->native(), $frames)
         );
+
+        return $image;
+    }
+
+    /**
+     * @throws VipsException
+     */
+    private function coverFromStash(
+        PathSource|BufferSource $stash,
+        SizeInterface $resize,
+        ColorspaceInterface $colorspace,
+    ): VipsImage {
+        $options = [
+            'height' => $resize->height(),
+            'crop' => Interesting::CENTRE,
+            'no_rotate' => true,
+        ];
+
+        $interpretation = ColorProcessor::colorspaceToInterpretation($colorspace);
+        if (in_array($interpretation, [Interpretation::CMYK, Interpretation::HSV], true)) {
+            $options['export-profile'] = $interpretation;
+        }
+
+        // stash->optionString intentionally not forwarded; thumbnail* is
+        // single-frame and n=-1 fails on single-frame loaders like pngload.
+        return $stash instanceof PathSource
+            ? VipsImage::thumbnail($stash->path, $resize->width(), $options)
+            : VipsImage::thumbnail_buffer($stash->buffer, $resize->width(), $options);
+    }
+
+    /**
+     * Re-apply the SRGB-3-band -> 4-band bandjoin that NativeObjectDecoder
+     * applies on first decode, so the post-thumbnail image's bandcount
+     * matches what the rest of the pipeline expects.
+     *
+     * @throws VipsException
+     */
+    private function normalizeBands(VipsImage $image): VipsImage
+    {
+        if ($image->interpretation === Interpretation::SRGB && $image->bands === 3) {
+            return $image->bandjoin_const(255);
+        }
 
         return $image;
     }

--- a/src/Modifiers/ResizeModifier.php
+++ b/src/Modifiers/ResizeModifier.php
@@ -5,10 +5,18 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers\Vips\Modifiers;
 
 use Intervention\Image\Drivers\Vips\ColorProcessor;
+use Intervention\Image\Drivers\Vips\Core;
+use Intervention\Image\Drivers\Vips\Source\BufferSource;
+use Intervention\Image\Drivers\Vips\Source\PathSource;
+use Intervention\Image\Exceptions\InvalidArgumentException;
+use Intervention\Image\Interfaces\ColorspaceInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SizeInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
 use Intervention\Image\Modifiers\ResizeModifier as GenericResizeModifier;
+use Jcupitt\Vips\Exception as VipsException;
+use Jcupitt\Vips\Image as VipsImage;
+use Jcupitt\Vips\Interpretation;
 
 class ResizeModifier extends GenericResizeModifier implements SpecializedInterface
 {
@@ -16,10 +24,23 @@ class ResizeModifier extends GenericResizeModifier implements SpecializedInterfa
      * {@inheritdoc}
      *
      * @see Intervention\Image\Interfaces\ModifierInterface::apply()
+     *
+     * @throws InvalidArgumentException
+     * @throws VipsException
      */
     public function apply(ImageInterface $image): ImageInterface
     {
         $resizeTo = $this->adjustedSize($image);
+        $core = $image->core();
+        $stash = $core instanceof Core ? $core->stashedSource() : null;
+
+        if ($stash !== null && !$image->isAnimated()) {
+            $core->setNative(
+                $this->normalizeBands($this->thumbnailFromStash($stash, $resizeTo, $image->colorspace()))
+            );
+
+            return $image;
+        }
 
         $options = [
             'height' => $resizeTo->height(),
@@ -45,5 +66,49 @@ class ResizeModifier extends GenericResizeModifier implements SpecializedInterfa
     protected function adjustedSize(ImageInterface $image): SizeInterface
     {
         return $image->size()->resize($this->width, $this->height);
+    }
+
+    /**
+     * @throws VipsException
+     */
+    private function thumbnailFromStash(
+        PathSource|BufferSource $stash,
+        SizeInterface $resizeTo,
+        ColorspaceInterface $colorspace,
+    ): VipsImage {
+        $options = [
+            'height' => $resizeTo->height(),
+            'size' => 'force',
+            'no_rotate' => true,
+        ];
+
+        $interpretation = ColorProcessor::colorspaceToInterpretation($colorspace);
+        if (in_array($interpretation, [Interpretation::CMYK, Interpretation::HSV], true)) {
+            $options['export-profile'] = $interpretation;
+        }
+
+        // Note: stash->optionString is intentionally NOT passed here.
+        // thumbnail* is single-frame; we already gated on !isAnimated().
+        // Multi-page options like n=-1 also fail on single-frame loaders
+        // such as pngload that do not recognise them.
+        return $stash instanceof PathSource
+            ? VipsImage::thumbnail($stash->path, $resizeTo->width(), $options)
+            : VipsImage::thumbnail_buffer($stash->buffer, $resizeTo->width(), $options);
+    }
+
+    /**
+     * Re-apply the SRGB-3-band -> 4-band bandjoin that NativeObjectDecoder
+     * applies on first decode, so the resized image's bandcount matches
+     * what the rest of the pipeline expects.
+     *
+     * @throws VipsException
+     */
+    private function normalizeBands(VipsImage $image): VipsImage
+    {
+        if ($image->interpretation === Interpretation::SRGB && $image->bands === 3) {
+            return $image->bandjoin_const(255);
+        }
+
+        return $image;
     }
 }

--- a/src/Source/BufferSource.php
+++ b/src/Source/BufferSource.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intervention\Image\Drivers\Vips\Source;
+
+/**
+ * The original buffer the image was decoded from, plus the libvips
+ * option-string the decoder used. Stashed on Core after a clean decode so
+ * that resize-family modifiers can swap to libvips' combined load+resize
+ * `thumbnail_buffer()` instead of `thumbnail_image()`.
+ */
+final readonly class BufferSource
+{
+    public function __construct(
+        public string $buffer,
+        public string $optionString = '',
+    ) {
+    }
+}

--- a/src/Source/PathSource.php
+++ b/src/Source/PathSource.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intervention\Image\Drivers\Vips\Source;
+
+/**
+ * The original file path the image was decoded from, plus the libvips
+ * option-string the decoder used. Stashed on Core after a clean decode so
+ * that resize-family modifiers can swap to libvips' combined load+resize
+ * `thumbnail()` instead of `thumbnail_image()`.
+ */
+final readonly class PathSource
+{
+    public function __construct(
+        public string $path,
+        public string $optionString = '',
+    ) {
+    }
+
+    /**
+     * Build the path argument including the option-string suffix that
+     * libvips file loaders accept (e.g. "/foo/bar.jpg[n=-1]").
+     */
+    public function pathWithOptions(): string
+    {
+        return $this->optionString === '' ? $this->path : $this->path . '[' . $this->optionString . ']';
+    }
+}

--- a/tests/Unit/CoreTest.php
+++ b/tests/Unit/CoreTest.php
@@ -7,6 +7,8 @@ namespace Intervention\Image\Drivers\Vips\Tests\Unit;
 use Intervention\Image\Drivers\Vips\Core;
 use Intervention\Image\Drivers\Vips\Driver;
 use Intervention\Image\Drivers\Vips\Frame;
+use Intervention\Image\Drivers\Vips\Source\BufferSource;
+use Intervention\Image\Drivers\Vips\Source\PathSource;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
 use Intervention\Image\Exceptions\InvalidArgumentException;
 use Intervention\Image\ImageManager;
@@ -135,5 +137,41 @@ class CoreTest extends BaseTestCase
         foreach ($this->core as $frame) {
             $this->assertInstanceOf(Frame::class, $frame);
         }
+    }
+
+    public function testStashedSourceIsNullByDefault(): void
+    {
+        $core = new Core($this->vipsImage(10, 10, [255, 0, 0]));
+
+        $this->assertNull($core->stashedSource());
+    }
+
+    public function testSetStashedSourcePathThenGet(): void
+    {
+        $core = new Core($this->vipsImage(10, 10, [255, 0, 0]));
+        $stash = new PathSource('/tmp/foo.jpg', 'n=-1');
+        $core->setStashedSource($stash);
+
+        $this->assertSame($stash, $core->stashedSource());
+    }
+
+    public function testSetStashedSourceBufferThenGet(): void
+    {
+        $core = new Core($this->vipsImage(10, 10, [255, 0, 0]));
+        $stash = new BufferSource('binary-bytes-here');
+        $core->setStashedSource($stash);
+
+        $this->assertSame($stash, $core->stashedSource());
+    }
+
+    public function testSetNativeClearsStashedSource(): void
+    {
+        $core = new Core($this->vipsImage(10, 10, [255, 0, 0]));
+        $core->setStashedSource(new PathSource('/tmp/foo.jpg'));
+        $this->assertNotNull($core->stashedSource());
+
+        $core->setNative($this->vipsImage(20, 20, [0, 255, 0]));
+
+        $this->assertNull($core->stashedSource());
     }
 }

--- a/tests/Unit/Decoders/BinaryImageDecoderTest.php
+++ b/tests/Unit/Decoders/BinaryImageDecoderTest.php
@@ -9,6 +9,7 @@ use Intervention\Image\Colors\Rgb\Colorspace as RgbColorspace;
 use Intervention\Image\Drivers\Vips\Decoders\BinaryImageDecoder;
 use Intervention\Image\Drivers\Vips\Driver;
 use Intervention\Image\Drivers\Vips\Modifiers\ResizeModifier;
+use Intervention\Image\Drivers\Vips\Source\BufferSource;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
 use Intervention\Image\Exceptions\InvalidArgumentException;
 use Intervention\Image\Image;
@@ -86,5 +87,16 @@ final class BinaryImageDecoderTest extends BaseTestCase
         $image->modify(new ResizeModifier(10, 10));
         $image->colorAt(7, 7)->toHex();
         $this->assertInstanceOf(Image::class, $image);
+    }
+
+    public function testDecodeStashesBufferSourceForCleanSrgbJpeg(): void
+    {
+        $bytes = $this->getTestResourceData('test.jpg');
+
+        $image = $this->decoder->decode($bytes);
+
+        $stash = $image->core()->stashedSource();
+        $this->assertInstanceOf(BufferSource::class, $stash);
+        $this->assertSame($bytes, $stash->buffer);
     }
 }

--- a/tests/Unit/Decoders/FilePathImageDecoderTest.php
+++ b/tests/Unit/Decoders/FilePathImageDecoderTest.php
@@ -6,6 +6,7 @@ namespace Intervention\Image\Drivers\Vips\Tests\Unit\Decoders;
 
 use Intervention\Image\Drivers\Vips\Analyzers\HeightAnalyzer;
 use Intervention\Image\Drivers\Vips\Modifiers\ResizeModifier;
+use Intervention\Image\Drivers\Vips\Source\PathSource;
 use Intervention\Image\Modifiers\BlurModifier;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Intervention\Image\Drivers\Vips\Decoders\FilePathImageDecoder;
@@ -61,6 +62,23 @@ final class FilePathImageDecoderTest extends BaseTestCase
         $analyzer->setDriver(new Driver());
         $analyzer->analyze($image);
         $this->assertInstanceOf(Image::class, $image);
+    }
+
+    public function testDecodeStashesPathSourceForCleanSrgbJpeg(): void
+    {
+        $image = $this->decoder->decode(self::getTestResourcePath('test.jpg'));
+
+        $stash = $image->core()->stashedSource();
+
+        $this->assertInstanceOf(PathSource::class, $stash);
+        $this->assertStringEndsWith('test.jpg', $stash->path);
+    }
+
+    public function testDecodeDoesNotStashWhenAutoOriented(): void
+    {
+        $image = $this->decoder->decode(self::getTestResourcePath('orientation.jpg'));
+
+        $this->assertNull($image->core()->stashedSource());
     }
 
     /**


### PR DESCRIPTION
This implements Cupitt's sketch from #55. Instead of running load and resize as two separate libvips calls, the resize-family modifiers now call `thumbnail()` / `thumbnail_buffer()` directly on the original source (file path or buffer).

For that to work, the decoder keeps a reference to the source. `FilePathImageDecoder` and `BinaryImageDecoder` store one on Core after a clean decode. Any modifier that mutates the image goes through `Core::setNative()`, which clears the reference. So the new path only kicks in for a chain of resizes right after a decode, with no other modifier in between.

It also only kicks in when `!isAnimated()`. CoverModifier additionally requires CENTER alignment, because libvips' `Interesting` enum has no directional crops.

Two readonly value classes (`Source\PathSource`, `Source\BufferSource`) hold the reference. The decoder does not store it for sources where the parent decoder transforms the image (BW/GREY16 to SRGB conversion, auto-rotation), since the source bytes can not reproduce that.

Bench (cover()+jpeg85, docker, libvips 8.18.1, php 8.3.31, noise JPEG fixtures):

| Source | Op | develop | this PR | Δ |
|---|---|---|---|---|
| 960x1280 | cover(800,300) | 13.09 ms | 13.22 ms | within noise |
| 4000x3000 | cover(800,300) | 63.26 ms | 53.94 ms | -15 % |
| 6000x4000 | cover(800,300) | 122.68 ms | 103.47 ms | -16 % |
| 6000x4000 | cover(150,100) | 138.94 ms | 83.63 ms | -40 % |

The speedup grows with source size and with how much smaller the target is. Cupitt reports ~4x on a real 6k x 4k photo in #55. Our fixtures are noise JPEGs, less favourable than real photos, so we see less.

Output bytes change a bit. The new path does not produce the same exact pixel values as decoding fully then resizing in memory. Cupitt acknowledged this in #55. Existing tests still pass without changing any pixel-value assertions.
