### PR TITLE
fix(modifiers): sync page-height after thumbnail_image on single-frame results

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -198,6 +198,38 @@ class Core implements CoreInterface, Iterator
     }
 
     /**
+     * Sync the page-height field to the actual native height for single-frame
+     * results.
+     *
+     * thumbnail_image()/embed()/etc. produce a new VipsImage that carries the
+     * input's page-height field. For multi-frame inputs (n-pages > 1) libvips
+     * scales page-height itself; for single-frame inputs the field is left
+     * stale, and HeightAnalyzer then reports the wrong height.
+     *
+     * @throws DriverException
+     */
+    public static function syncPageHeight(VipsImage $native): VipsImage
+    {
+        try {
+            $fields = $native->getFields();
+
+            if (!in_array('page-height', $fields, true)) {
+                return $native;
+            }
+
+            if (in_array('n-pages', $fields, true) && (int) $native->get('n-pages') > 1) {
+                return $native;
+            }
+
+            $native->set('page-height', $native->height);
+        } catch (VipsException $e) {
+            throw new DriverException('Failed to sync page-height field', previous: $e);
+        }
+
+        return $native;
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @see CoreInterface::count()

--- a/src/Modifiers/ContainDownModifier.php
+++ b/src/Modifiers/ContainDownModifier.php
@@ -37,12 +37,12 @@ class ContainDownModifier extends ContainModifier
         );
 
         if (!$image->isAnimated()) {
-            $contained = $this->containDown(
+            $contained = Core::syncPageHeight($this->containDown(
                 $image->core()->first(),
                 $targetSize,
                 $bgColor,
                 $colorspace,
-            )->native();
+            )->native());
         } else {
             $frames = [];
             foreach ($image as $frame) {

--- a/src/Modifiers/ContainModifier.php
+++ b/src/Modifiers/ContainModifier.php
@@ -49,12 +49,12 @@ class ContainModifier extends GenericContainModifier implements SpecializedInter
         );
 
         if (!$image->isAnimated()) {
-            $contained = $this->contain(
+            $contained = Core::syncPageHeight($this->contain(
                 $image->core()->first(),
                 $targetSize,
                 $bgColor,
                 $colorspace,
-            )->native();
+            )->native());
         } else {
             $frames = [];
             foreach ($image as $frame) {

--- a/src/Modifiers/CoverModifier.php
+++ b/src/Modifiers/CoverModifier.php
@@ -67,7 +67,7 @@ class CoverModifier extends GenericCoverModifier implements SpecializedInterface
                 );
             }
 
-            $core->setNative($native);
+            $core->setNative(Core::syncPageHeight($native));
 
             return $image;
         }
@@ -80,7 +80,7 @@ class CoverModifier extends GenericCoverModifier implements SpecializedInterface
                 $resize,
                 $colorspace,
             );
-            $core->setNative($native);
+            $core->setNative(Core::syncPageHeight($native));
 
             return $image;
         }

--- a/src/Modifiers/ResizeModifier.php
+++ b/src/Modifiers/ResizeModifier.php
@@ -9,6 +9,7 @@ use Intervention\Image\Drivers\Vips\Core;
 use Intervention\Image\Drivers\Vips\Source\BufferSource;
 use Intervention\Image\Drivers\Vips\Source\PathSource;
 use Intervention\Image\Drivers\Vips\Traits\CanNormalizeBands;
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\InvalidArgumentException;
 use Intervention\Image\Interfaces\ColorspaceInterface;
 use Intervention\Image\Interfaces\ImageInterface;
@@ -30,6 +31,7 @@ class ResizeModifier extends GenericResizeModifier implements SpecializedInterfa
      *
      * @throws InvalidArgumentException
      * @throws VipsException
+     * @throws DriverException
      */
     public function apply(ImageInterface $image): ImageInterface
     {
@@ -60,9 +62,9 @@ class ResizeModifier extends GenericResizeModifier implements SpecializedInterfa
             $options['export-profile'] = $exportProfile;
         }
 
-        $image->core()->setNative(
+        $image->core()->setNative(Core::syncPageHeight(
             $image->core()->native()->thumbnail_image($resizeTo->width(), $options)
-        );
+        ));
 
         return $image;
     }

--- a/tests/Unit/Modifiers/ContainDownModifierTest.php
+++ b/tests/Unit/Modifiers/ContainDownModifierTest.php
@@ -6,6 +6,7 @@ namespace Intervention\Image\Drivers\Vips\Tests\Unit\Modifiers;
 
 use Intervention\Image\Drivers\Vips\Modifiers\ContainDownModifier;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
+use Intervention\Image\Modifiers\SliceAnimationModifier;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(ContainDownModifier::class)]
@@ -63,5 +64,20 @@ final class ContainDownModifierTest extends BaseTestCase
         $this->assertColor(255, 0, 0, 255, $image->colorAt(0, 257));
         $this->assertColor(255, 0, 0, 255, $image->colorAt(257, 0));
         $this->assertColor(255, 0, 0, 255, $image->colorAt(257, 257));
+    }
+
+    /**
+     * Regression: thumbnail_image() carries the input's stale page-height
+     * field over to the result. Surfaces after SliceAnimationModifier reduces
+     * an animated source to a single frame but leaves page-height set.
+     */
+    public function testModifyUpdatesPageHeightAfterSliceAnimation(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $image->modify(new SliceAnimationModifier(0, 1));
+        $image->modify(new ContainDownModifier(40, 30, 'f00'));
+
+        $this->assertSame(40, $image->width());
+        $this->assertSame(30, $image->height());
     }
 }

--- a/tests/Unit/Modifiers/ContainModifierTest.php
+++ b/tests/Unit/Modifiers/ContainModifierTest.php
@@ -7,6 +7,7 @@ namespace Intervention\Image\Drivers\Vips\Tests\Unit\Modifiers;
 use Intervention\Image\Drivers\Vips\Driver;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
 use Intervention\Image\Modifiers\ContainModifier;
+use Intervention\Image\Modifiers\SliceAnimationModifier;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(ContainModifier::class)]
@@ -88,5 +89,20 @@ final class ContainModifierTest extends BaseTestCase
         $this->assertEquals(256, $image->height());
         $this->assertColor(255, 255, 255, 0, $image->colorAt(0, 0));
         $this->assertColor(0, 0, 0, 127, $image->colorAt(1, 0), 1);
+    }
+
+    /**
+     * Regression: thumbnail_image() carries the input's stale page-height
+     * field over to the result. Surfaces after SliceAnimationModifier reduces
+     * an animated source to a single frame but leaves page-height set.
+     */
+    public function testModifyUpdatesPageHeightAfterSliceAnimation(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $image->modify(new SliceAnimationModifier(0, 1));
+        $image->modify(new ContainModifier(40, 30));
+
+        $this->assertSame(40, $image->width());
+        $this->assertSame(30, $image->height());
     }
 }

--- a/tests/Unit/Modifiers/CoverModifierTest.php
+++ b/tests/Unit/Modifiers/CoverModifierTest.php
@@ -7,6 +7,7 @@ namespace Intervention\Image\Drivers\Vips\Tests\Unit\Modifiers;
 use Intervention\Image\Colors\Rgb\Color;
 use Intervention\Image\Drivers\Vips\Driver;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
+use Intervention\Image\Modifiers\SliceAnimationModifier;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Intervention\Image\Modifiers\CoverModifier;
 
@@ -57,5 +58,20 @@ final class CoverModifierTest extends BaseTestCase
         $this->assertEquals(50, $image->width());
         $this->assertEquals(50, $image->height());
         $this->assertMediaType('image/jpeg', $image->encode());
+    }
+
+    /**
+     * Regression: thumbnail_image() carries the input's stale page-height
+     * field over to the result. Surfaces after SliceAnimationModifier reduces
+     * an animated source to a single frame but leaves page-height set.
+     */
+    public function testModifyUpdatesPageHeightAfterSliceAnimation(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $image->modify(new SliceAnimationModifier(0, 1));
+        $image->modify(new CoverModifier(40, 30, 'center'));
+
+        $this->assertSame(40, $image->width());
+        $this->assertSame(30, $image->height());
     }
 }

--- a/tests/Unit/Modifiers/ResizeModifierTest.php
+++ b/tests/Unit/Modifiers/ResizeModifierTest.php
@@ -6,6 +6,7 @@ namespace Intervention\Image\Drivers\Vips\Tests\Unit\Modifiers;
 
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
 use Intervention\Image\Modifiers\ResizeModifier;
+use Intervention\Image\Modifiers\SliceAnimationModifier;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(ResizeModifier::class)]
@@ -31,5 +32,22 @@ final class ResizeModifierTest extends BaseTestCase
         $image->modify(new ResizeModifier(10, 10));
         $this->assertEquals(10, $image->width());
         $this->assertEquals(10, $image->height());
+    }
+
+    /**
+     * Regression: thumbnail_image() carries the input's page-height field
+     * over to the result without updating it. HeightAnalyzer prefers
+     * page-height when set, so the resized image reported the stale value.
+     * Surfaces here via SliceAnimationModifier(0, 1) on an animated source,
+     * which leaves page-height set on the now-single-frame native.
+     */
+    public function testResizeUpdatesPageHeightAfterSliceAnimation(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $image->modify(new SliceAnimationModifier(0, 1));
+        $image->modify(new ResizeModifier(40, 30));
+
+        $this->assertSame(40, $image->width());
+        $this->assertSame(30, $image->height());
     }
 }


### PR DESCRIPTION
libvips's thumbnail_image()/embed()/etc. produce a new VipsImage that carries the input's page-height field. For multi-frame inputs (n-pages > 1) libvips scales page-height itself; for single-frame inputs the field is left stale. HeightAnalyzer prefers page-height when set, so the resulting image reports the wrong height.

Surfaces after SliceAnimationModifier(0, 1) on an animated source — the post-slice native is single-frame but still carries page-height from the animation. Any subsequent resize-family modifier produces a result whose page-height does not match its actual height.

Add Core::syncPageHeight() that resets page-height to the native height when present and the image is single-frame, then call it from the single-frame paths of ResizeModifier, CoverModifier, ContainModifier, and ContainDownModifier. The multi-frame paths go through replaceFrames(), which already sets page-height correctly.

One regression test per modifier covering the slice-then-resize chain.