### PR TITLE
Fix bug when previous animations are removed and then resized

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -55,16 +55,21 @@ class Core implements CoreInterface, Iterator
         }
 
         try {
-            $image = VipsImage::arrayjoin($natives, ['across' => 1]);
-            $image->set('delay', $delay);
-            $image->set('loop', $loops);
-            $image->set('page-height', $natives[0]->height);
-            $image->set('n-pages', count($frames));
+            $vipsImage = VipsImage::arrayjoin($natives, ['across' => 1]);
+            $vipsImage->set('delay', $delay);
+            $vipsImage->set('loop', $loops);
+            $vipsImage->set('n-pages', count($frames));
+
+            if (count($frames) > 1) {
+                $vipsImage->set('page-height', $natives[0]->height);
+            } elseif (in_array('page-height', $vipsImage->getFields())) {
+                $vipsImage->remove('page-height');
+            }
         } catch (VipsException $e) {
             throw new DriverException('Failed to create image core from frames', previous: $e);
         }
 
-        return new self($image);
+        return new self($vipsImage);
     }
 
     /**

--- a/src/Modifiers/RemoveAnimationModifier.php
+++ b/src/Modifiers/RemoveAnimationModifier.php
@@ -9,7 +9,6 @@ use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
 use Intervention\Image\Modifiers\RemoveAnimationModifier as GenericRemoveAnimationModifier;
-use Jcupitt\Vips\Exception as VipsException;
 
 class RemoveAnimationModifier extends GenericRemoveAnimationModifier implements SpecializedInterface
 {
@@ -27,23 +26,6 @@ class RemoveAnimationModifier extends GenericRemoveAnimationModifier implements 
             return $image;
         }
 
-        $position = parent::normalizePosition($image);
-        $pageHeight = $image->core()->native()->get('page-height');
-
-        try {
-            $modified = $image->core()->native()->crop(
-                0,
-                $position * $pageHeight,
-                $image->width(),
-                $pageHeight,
-            );
-            $modified->set('n-pages', 1);
-        } catch (VipsException) {
-            throw new ModifierException('Frame #' . $position . ' could not be found in the image.');
-        }
-
-        $image->core()->setNative($modified);
-
-        return $image;
+        return $image->sliceAnimation(parent::normalizePosition($image), 1);
     }
 }

--- a/tests/Unit/Modifiers/ContainDownModifierTest.php
+++ b/tests/Unit/Modifiers/ContainDownModifierTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers\Vips\Tests\Unit\Modifiers;
 
 use Intervention\Image\Drivers\Vips\Modifiers\ContainDownModifier;
+use Intervention\Image\Drivers\Vips\Modifiers\RemoveAnimationModifier;
+use Intervention\Image\Drivers\Vips\Modifiers\SliceAnimationModifier;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -63,5 +65,27 @@ final class ContainDownModifierTest extends BaseTestCase
         $this->assertColor(255, 0, 0, 255, $image->colorAt(0, 257));
         $this->assertColor(255, 0, 0, 255, $image->colorAt(257, 0));
         $this->assertColor(255, 0, 0, 255, $image->colorAt(257, 257));
+    }
+
+    public function testModifyContainDownRemovedAnimation(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $this->assertEquals(20, $image->width());
+        $this->assertEquals(15, $image->height());
+        $image->modify(new RemoveAnimationModifier());
+        $image->modify(new ContainDownModifier(200, 100, 'ffffff00'));
+        $this->assertEquals(200, $image->width());
+        $this->assertEquals(100, $image->height());
+    }
+
+    public function testModifyContainDownSlicedAnimation(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $this->assertEquals(20, $image->width());
+        $this->assertEquals(15, $image->height());
+        $image->modify(new SliceAnimationModifier(0, 1));
+        $image->modify(new ContainDownModifier(200, 100, 'ffffff00'));
+        $this->assertEquals(200, $image->width());
+        $this->assertEquals(100, $image->height());
     }
 }

--- a/tests/Unit/Modifiers/ContainModifierTest.php
+++ b/tests/Unit/Modifiers/ContainModifierTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers\Vips\Tests\Unit\Modifiers;
 
 use Intervention\Image\Drivers\Vips\Driver;
+use Intervention\Image\Drivers\Vips\Modifiers\RemoveAnimationModifier;
+use Intervention\Image\Drivers\Vips\Modifiers\SliceAnimationModifier;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
 use Intervention\Image\Modifiers\ContainModifier;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -88,5 +90,27 @@ final class ContainModifierTest extends BaseTestCase
         $this->assertEquals(256, $image->height());
         $this->assertColor(255, 255, 255, 0, $image->colorAt(0, 0));
         $this->assertColor(0, 0, 0, 127, $image->colorAt(1, 0), 1);
+    }
+
+    public function testModifyContainRemovedAnimation(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $this->assertEquals(20, $image->width());
+        $this->assertEquals(15, $image->height());
+        $image->modify(new RemoveAnimationModifier());
+        $image->modify(new ContainModifier(200, 100, 'ffffff00'));
+        $this->assertEquals(200, $image->width());
+        $this->assertEquals(100, $image->height());
+    }
+
+    public function testModifyContainSlicedAnimation(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $this->assertEquals(20, $image->width());
+        $this->assertEquals(15, $image->height());
+        $image->modify(new SliceAnimationModifier(0, 1));
+        $image->modify(new ContainModifier(200, 100, 'ffffff00'));
+        $this->assertEquals(200, $image->width());
+        $this->assertEquals(100, $image->height());
     }
 }

--- a/tests/Unit/Modifiers/CoverDownModifierTest.php
+++ b/tests/Unit/Modifiers/CoverDownModifierTest.php
@@ -6,6 +6,8 @@ namespace Intervention\Image\Drivers\Vips\Tests\Unit\Modifiers;
 
 use Intervention\Image\Colors\Rgb\Color;
 use Intervention\Image\Drivers\Vips\Driver;
+use Intervention\Image\Drivers\Vips\Modifiers\RemoveAnimationModifier;
+use Intervention\Image\Drivers\Vips\Modifiers\SliceAnimationModifier;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Intervention\Image\Modifiers\CoverDownModifier;
@@ -47,5 +49,27 @@ final class CoverDownModifierTest extends BaseTestCase
             array_map(fn(Color $color): string => $color->toHex(), $image->colorsAt(8, 8)->toArray()),
             ['ffa601', 'ffa601', 'ffa601', 'ffa601', '394b63', '394b63', '394b63', '394b63']
         );
+    }
+
+    public function testModifyRemovedAnimation(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $this->assertEquals(20, $image->width());
+        $this->assertEquals(15, $image->height());
+        $image->modify(new RemoveAnimationModifier());
+        $image->modify(new CoverDownModifier(10, 8, 'center'));
+        $this->assertEquals(10, $image->width());
+        $this->assertEquals(8, $image->height());
+    }
+
+    public function testModifySlicedAnimation(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $this->assertEquals(20, $image->width());
+        $this->assertEquals(15, $image->height());
+        $image->modify(new SliceAnimationModifier(0, 1));
+        $image->modify(new CoverDownModifier(10, 8, 'center'));
+        $this->assertEquals(10, $image->width());
+        $this->assertEquals(8, $image->height());
     }
 }

--- a/tests/Unit/Modifiers/CoverModifierTest.php
+++ b/tests/Unit/Modifiers/CoverModifierTest.php
@@ -6,6 +6,8 @@ namespace Intervention\Image\Drivers\Vips\Tests\Unit\Modifiers;
 
 use Intervention\Image\Colors\Rgb\Color;
 use Intervention\Image\Drivers\Vips\Driver;
+use Intervention\Image\Drivers\Vips\Modifiers\RemoveAnimationModifier;
+use Intervention\Image\Drivers\Vips\Modifiers\SliceAnimationModifier;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Intervention\Image\Modifiers\CoverModifier;
@@ -57,5 +59,27 @@ final class CoverModifierTest extends BaseTestCase
         $this->assertEquals(50, $image->width());
         $this->assertEquals(50, $image->height());
         $this->assertMediaType('image/jpeg', $image->encode());
+    }
+
+    public function testModifyCoverRemovedAnimation(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $this->assertEquals(20, $image->width());
+        $this->assertEquals(15, $image->height());
+        $image->modify(new RemoveAnimationModifier());
+        $image->modify(new CoverModifier(200, 100, 'center'));
+        $this->assertEquals(200, $image->width());
+        $this->assertEquals(100, $image->height());
+    }
+
+    public function testModifyCoverSlicedAnimation(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $this->assertEquals(20, $image->width());
+        $this->assertEquals(15, $image->height());
+        $image->modify(new SliceAnimationModifier(0, 1));
+        $image->modify(new CoverModifier(200, 100, 'center'));
+        $this->assertEquals(200, $image->width());
+        $this->assertEquals(100, $image->height());
     }
 }

--- a/tests/Unit/Modifiers/CropModifierTest.php
+++ b/tests/Unit/Modifiers/CropModifierTest.php
@@ -6,6 +6,8 @@ namespace Intervention\Image\Drivers\Vips\Tests\Unit\Modifiers;
 
 use Intervention\Image\Colors\Rgb\Color;
 use Intervention\Image\Drivers\Vips\Driver;
+use Intervention\Image\Drivers\Vips\Modifiers\RemoveAnimationModifier;
+use Intervention\Image\Drivers\Vips\Modifiers\SliceAnimationModifier;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
 use Intervention\Image\Modifiers\CropModifier;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -111,5 +113,27 @@ final class CropModifierTest extends BaseTestCase
 
         // Ensure the image is encodable
         $image->encode();
+    }
+
+    public function testModifyCropRemovedAnimation(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $this->assertEquals(20, $image->width());
+        $this->assertEquals(15, $image->height());
+        $image->modify(new RemoveAnimationModifier());
+        $image->modify(new CropModifier(10, 8));
+        $this->assertEquals(10, $image->width());
+        $this->assertEquals(8, $image->height());
+    }
+
+    public function testModifyCropSlicedAnimation(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $this->assertEquals(20, $image->width());
+        $this->assertEquals(15, $image->height());
+        $image->modify(new SliceAnimationModifier(0, 1));
+        $image->modify(new CropModifier(10, 8));
+        $this->assertEquals(10, $image->width());
+        $this->assertEquals(8, $image->height());
     }
 }

--- a/tests/Unit/Modifiers/ResizeCanvasModifierTest.php
+++ b/tests/Unit/Modifiers/ResizeCanvasModifierTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Tests\Unit\Modifiers;
 
+use Intervention\Image\Drivers\Vips\Modifiers\RemoveAnimationModifier;
 use Intervention\Image\Drivers\Vips\Modifiers\ResizeCanvasModifier;
+use Intervention\Image\Drivers\Vips\Modifiers\SliceAnimationModifier;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -62,5 +64,27 @@ final class ResizeCanvasModifierTest extends BaseTestCase
         $this->assertEquals(2, $image->height());
         $this->assertColor(255, 255, 0, 255, $image->colorAt(0, 0));
         $this->assertColor(255, 0, 0, 255, $image->colorAt(0, 1));
+    }
+
+    public function testModifyRemovedAnimation(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $this->assertEquals(20, $image->width());
+        $this->assertEquals(15, $image->height());
+        $image->modify(new RemoveAnimationModifier());
+        $image->modify(new ResizeCanvasModifier(30, 25, 'ff0', 'center'));
+        $this->assertEquals(30, $image->width());
+        $this->assertEquals(25, $image->height());
+    }
+
+    public function testModifySlicedAnimation(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $this->assertEquals(20, $image->width());
+        $this->assertEquals(15, $image->height());
+        $image->modify(new SliceAnimationModifier(0, 1));
+        $image->modify(new ResizeCanvasModifier(30, 25, 'ff0', 'center'));
+        $this->assertEquals(30, $image->width());
+        $this->assertEquals(25, $image->height());
     }
 }

--- a/tests/Unit/Modifiers/ResizeCanvasRelativeModifierTest.php
+++ b/tests/Unit/Modifiers/ResizeCanvasRelativeModifierTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Tests\Unit\Modifiers;
 
+use Intervention\Image\Drivers\Vips\Modifiers\RemoveAnimationModifier;
 use Intervention\Image\Drivers\Vips\Modifiers\ResizeCanvasRelativeModifier;
+use Intervention\Image\Drivers\Vips\Modifiers\SliceAnimationModifier;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -37,5 +39,27 @@ final class ResizeCanvasRelativeModifierTest extends BaseTestCase
         $this->assertColor(180, 224, 0, 255, $image->colorAt(2, 2));
         $this->assertColor(255, 255, 0, 255, $image->colorAt(17, 17));
         $this->assertTransparency($image->colorAt(12, 1));
+    }
+
+    public function testModifyRemovedAnimation(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $this->assertEquals(20, $image->width());
+        $this->assertEquals(15, $image->height());
+        $image->modify(new RemoveAnimationModifier());
+        $image->modify(new ResizeCanvasRelativeModifier(10, 5, 'ff0', 'center'));
+        $this->assertEquals(30, $image->width());
+        $this->assertEquals(20, $image->height());
+    }
+
+    public function testModifySlicedAnimation(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $this->assertEquals(20, $image->width());
+        $this->assertEquals(15, $image->height());
+        $image->modify(new SliceAnimationModifier(0, 1));
+        $image->modify(new ResizeCanvasRelativeModifier(10, 5, 'ff0', 'center'));
+        $this->assertEquals(30, $image->width());
+        $this->assertEquals(20, $image->height());
     }
 }

--- a/tests/Unit/Modifiers/ResizeModifierTest.php
+++ b/tests/Unit/Modifiers/ResizeModifierTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Tests\Unit\Modifiers;
 
+use Intervention\Image\Drivers\Vips\Modifiers\RemoveAnimationModifier;
+use Intervention\Image\Drivers\Vips\Modifiers\SliceAnimationModifier;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
 use Intervention\Image\Modifiers\ResizeModifier;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -31,5 +33,27 @@ final class ResizeModifierTest extends BaseTestCase
         $image->modify(new ResizeModifier(10, 10));
         $this->assertEquals(10, $image->width());
         $this->assertEquals(10, $image->height());
+    }
+
+    public function testResizeRemovedAnimation(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $this->assertEquals(20, $image->width());
+        $this->assertEquals(15, $image->height());
+        $image->modify(new RemoveAnimationModifier());
+        $image->modify(new ResizeModifier(200, 100));
+        $this->assertEquals(200, $image->width());
+        $this->assertEquals(100, $image->height());
+    }
+
+    public function testResizeSlicedAnimation(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $this->assertEquals(20, $image->width());
+        $this->assertEquals(15, $image->height());
+        $image->modify(new SliceAnimationModifier(0, 1));
+        $image->modify(new ResizeModifier(200, 100));
+        $this->assertEquals(200, $image->width());
+        $this->assertEquals(100, $image->height());
     }
 }


### PR DESCRIPTION
Fixes bug discovered by @nlemoine when resizing previously animated images which were sliced to single frame images.


```php
use Intervention\Image\Drivers\Vips\Driver as VipsDriver;
use Intervention\Image\ImageManager;

$image = ImageManager::usingDriver(VipsDriver::class)
    ->decode('animation.gif') // original image: 20 x 15, 8 frames
    ->sliceAnimation(0, 1) // slice to single frame
    ->cover(10, 5); // resize

$image->height(); // should be 5, is 15
```