### PR TITLE
perf(encoders): set web-tuned effort default (heif=1, webp=2)

### DIFF
--- a/src/Encoders/AvifEncoder.php
+++ b/src/Encoders/AvifEncoder.php
@@ -42,13 +42,16 @@ class AvifEncoder extends GenericAvifEncoder implements SpecializedInterface
 
     /**
      * @throws StateException
-     * @return array{lossless: bool, Q: int, keep?: int, strip?: bool}
+     * @return array{lossless: bool, Q: int, effort: int, keep?: int, strip?: bool}
      */
     private function options(): array
     {
         $options = [
             'lossless' => $this->quality === 100,
             'Q' => $this->quality,
+            // libvips' heifsave defaults to effort=4; 1 encodes ~2-3x faster
+            // with near-identical bytes on typical web sources (range 0..9).
+            'effort' => 1,
         ];
 
         $strip = $this->strip || $this->driver()->config()->strip;

--- a/src/Encoders/HeicEncoder.php
+++ b/src/Encoders/HeicEncoder.php
@@ -42,13 +42,16 @@ class HeicEncoder extends GenericHeicEncoder implements SpecializedInterface
 
     /**
      * @throws StateException
-     * @return array{lossless: bool, Q: int, keep?: int, strip?: bool}
+     * @return array{lossless: bool, Q: int, effort: int, keep?: int, strip?: bool}
      */
     private function options(): array
     {
         $options = [
             'lossless' => $this->quality === 100,
             'Q' => $this->quality,
+            // libvips' heifsave defaults to effort=4; 1 encodes ~2-3x faster
+            // with near-identical bytes on typical web sources (range 0..9).
+            'effort' => 1,
         ];
 
         $strip = $this->strip || $this->driver()->config()->strip;

--- a/src/Encoders/WebpEncoder.php
+++ b/src/Encoders/WebpEncoder.php
@@ -42,13 +42,17 @@ class WebpEncoder extends GenericWebpEncoder implements SpecializedInterface
 
     /**
      * @throws StateException
-     * @return array{lossless: bool, Q: int, keep?: int, strip?: bool}
+     * @return array{lossless: bool, Q: int, effort: int, keep?: int, strip?: bool}
      */
     private function options(): array
     {
         $options = [
             'lossless' => $this->quality === 100,
             'Q' => $this->quality,
+            // libvips' webpsave defaults to effort=4; 2 roughly halves encode
+            // time while staying within ~3% bytes (effort=1 costs +10-19%;
+            // range 0..6).
+            'effort' => 2,
         ];
 
         $strip = $this->strip || $this->driver()->config()->strip;


### PR DESCRIPTION
The Vips Avif, Heic and Webp encoders set lossless, Q and keep, but they never pass libvips' `effort`. So they inherit libvips' default of effort=4 (heifsave range 0..9, webpsave range 0..6), which is slower than needed for web encodes.

This sets effort=1 for heif (avif/heic) and effort=2 for webp.

I found this on a demo that negotiates AVIF from the browser Accept header. The Vips driver was slower than GD on the same encode, and it turned out to be the effort default.

Repro on libvips 8.18.2, decode + encode, best of 3, Q=75 for AVIF, Q=80 for WebP. Cells are ms / output bytes, percent is bytes vs the default.

AVIF (heifsave):

| source | default (=4) | effort=1 | effort=2 |
|---|---:|---:|---:|
| 960x1280 JPEG | 146 ms / 54540 | 21 ms / 35690 (-35%) | 31 ms / 35042 (-36%) |
| 1920x1280 JPEG | 412 ms / 233269 | 60 ms / 241511 (+4%) | 153 ms / 240761 (+3%) |
| 4000x2667 JPEG | 1300 ms / 394542 | 147 ms / 404564 (+3%) | 445 ms / 405572 (+3%) |
| 2000x2000 RGBA PNG | 537 ms / 246386 | 114 ms / 264800 (+7%) | 214 ms / 252485 (+2%) |

WebP (webpsave):

| source | default (=4) | effort=1 | effort=2 |
|---|---:|---:|---:|
| 960x1280 JPEG | 49 ms / 35442 | 16 ms / 40044 (+13%) | 21 ms / 36500 (+3%) |
| 1920x1280 JPEG | 138 ms / 225012 | 55 ms / 259642 (+15%) | 71 ms / 234594 (+4%) |
| 4000x2667 JPEG | 462 ms / 399278 | 165 ms / 474912 (+19%) | 215 ms / 420262 (+5%) |
| 2000x2000 RGBA PNG | 223 ms / 262288 | 137 ms / 295696 (+13%) | 149 ms / 270972 (+3%) |

Reasoning for the values:

- default and effort=4 are byte-identical in every row, so 4 is the live default.
- For heifsave, effort=1 is about 2-3x faster than effort=2 with basically the same bytes on photos. effort=2 only helps on the RGBA source (about 5% smaller, still about 2x slower), so 1 is the better default.
- For webpsave it is the other way, effort=1 costs +13-19% bytes, so 2 is the sweet spot.
- effort=0 is faster still but not safe as a default, the RGBA source blew up (+63% AVIF, +122% WebP).

No version gate: both CI libvips versions (8.17.2 and 8.18.1) have effort on both ops.

On tests: effort leaves no readable trace in the output (unlike progressive on JpegEncoder), so there is nothing stable to assert on the encoded bytes across libvips builds. The existing encoder tests now exercise the effort path on both CI versions. This matches how optimize_coding=true is already set on JpegEncoder without a dedicated test.