### PR TITLE
Add JPEG XL (JXL) encoder

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,6 +41,7 @@ jobs:
             libheif-dev \
             libheif-plugin-aomenc \
             libheif-plugin-x265 \
+            libjxl-dev \
             libcgif-dev \
             libimagequant-dev \
             libopenjp2-7-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt update \
             libheif-dev \
             libheif-plugin-aomenc \
             libheif-plugin-x265 \
+            libjxl-dev \
             libcgif-dev \
             libimagequant-dev \
             libopenjp2-7-dev \

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^8.3",
-        "intervention/image": "^4.0.2",
+        "intervention/image": "^4.2",
         "jcupitt/vips": "^2.6"
     },
     "require-dev": {

--- a/src/Encoders/JxlEncoder.php
+++ b/src/Encoders/JxlEncoder.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intervention\Image\Drivers\Vips\Encoders;
+
+use Intervention\Image\EncodedImage;
+use Intervention\Image\Encoders\JxlEncoder as GenericJxlEncoder;
+use Intervention\Image\Exceptions\EncoderException;
+use Intervention\Image\Exceptions\StreamException;
+use Intervention\Image\Exceptions\InvalidArgumentException;
+use Intervention\Image\Exceptions\StateException;
+use Intervention\Image\Interfaces\ImageInterface;
+use Intervention\Image\Interfaces\SpecializedInterface;
+use Intervention\Image\MediaType;
+use Jcupitt\Vips\Config as VipsConfig;
+use Jcupitt\Vips\Exception as VipsException;
+use Jcupitt\Vips\ForeignKeep;
+
+class JxlEncoder extends GenericJxlEncoder implements SpecializedInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see Intervention\Image\Interfaces\EncoderInterface::encode()
+     *
+     * @throws InvalidArgumentException
+     * @throws EncoderException
+     * @throws StreamException
+     * @throws StateException
+     */
+    public function encode(ImageInterface $image): EncodedImage
+    {
+        try {
+            $result = $image->core()->native()->writeToBuffer('.jxl', $this->options());
+        } catch (VipsException $e) {
+            throw new EncoderException('Failed to encode JXL image format', previous: $e);
+        }
+
+        return new EncodedImage($result, MediaType::IMAGE_JXL->value);
+    }
+
+    /**
+     * libvips' jxlsave has a native lossless flag. JXL has no separate lossless
+     * setting beyond maximum quality, so it is enabled at Q 100, matching the
+     * AVIF and HEIC encoders of this driver.
+     *
+     * @throws StateException
+     * @return array{lossless: bool, Q: int, keep?: int, strip?: bool}
+     */
+    private function options(): array
+    {
+        $options = [
+            'lossless' => $this->quality === 100,
+            'Q' => $this->quality,
+        ];
+
+        $strip = $this->strip || $this->driver()->config()->strip;
+
+        if (VipsConfig::atLeast(8, 15)) {
+            $keepAll = VipsConfig::atLeast(8, 18)
+                ? ForeignKeep::ALL
+                : ForeignKeep::ALL & ~ForeignKeep::GAINMAP;
+            $options['keep'] = $strip ? ForeignKeep::ICC : $keepAll;
+        } else {
+            $options['strip'] = $strip;
+        }
+
+        return $options;
+    }
+}

--- a/src/LoaderDetector.php
+++ b/src/LoaderDetector.php
@@ -117,6 +117,10 @@ class LoaderDetector
                 case 'jp2k':
                     $formats[] = Format::JP2;
                     break;
+
+                case 'jxl':
+                    $formats[] = Format::JXL;
+                    break;
             }
         }
 

--- a/tests/Unit/DriverTest.php
+++ b/tests/Unit/DriverTest.php
@@ -168,6 +168,14 @@ class DriverTest extends BaseTestCase
         yield [true, 'image/heic'];
         yield [true, 'image/heif'];
 
+        yield [true, Format::JXL];
+        yield [true, MediaType::IMAGE_JXL];
+        yield [true, MediaType::IMAGE_X_JXL];
+        yield [true, FileExtension::JXL];
+        yield [true, 'jxl'];
+        yield [true, 'image/jxl'];
+        yield [true, 'image/x-jxl'];
+
         yield [false, 'tga'];
         yield [false, 'image/tga'];
         yield [false, 'image/x-targa'];

--- a/tests/Unit/Encoders/JxlEncoderTest.php
+++ b/tests/Unit/Encoders/JxlEncoderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intervention\Image\Drivers\Vips\Tests\Unit\Encoders;
+
+use Intervention\Image\Drivers\Vips\Driver;
+use Intervention\Image\Drivers\Vips\Encoders\JxlEncoder;
+use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(JxlEncoder::class)]
+final class JxlEncoderTest extends BaseTestCase
+{
+    public function testEncode(): void
+    {
+        $image = (new Driver())->createImage(3, 2);
+        $encoder = new JxlEncoder(75);
+        $encoder->setDriver(new Driver());
+        $result = $encoder->encode($image);
+        $this->assertMediaType(['image/jxl', 'image/x-jxl'], $result);
+        $this->assertEquals('image/jxl', $result->mimetype());
+    }
+}


### PR DESCRIPTION
This adds JPEG XL as an encodable format in the vips driver.

It follows the `AvifEncoder` and `HeicEncoder`. Encoding goes through libvips' `jxlsave` via `writeToBuffer('.jxl', ...)`. libvips' `jxlsave` has a native `lossless` flag, but JXL has no separate lossless setting beyond maximum quality, so I enable it at `Q` 100, same as the AVIF and HEIC encoders here.

`LoaderDetector` now maps the `jxl` loader to `Format::JXL`. Without that, `supports(Format::JXL)` returns false even when libvips has the loader.

For CI and Docker I added `libjxl-dev` to the apt list. Both build libvips from source, and libvips enables JXL when libjxl is present at build time. Both bases (Debian for the `Dockerfile`, `ubuntu-24.04` for CI) have `libjxl-dev` in apt.

This needs the JXL support from core, so it requires `intervention/image` `^4.2` (JXL shipped in 4.2.0).

I ran the suite in Docker against libvips 8.18.1 built with libjxl, all green. The `JxlEncoder` test does a real `jxlsave`, and the driver reports `supports(Format::JXL)`.