### PR TITLE
Fix pipeline depth guard

### DIFF
--- a/src/Analyzers/PixelColorAnalyzer.php
+++ b/src/Analyzers/PixelColorAnalyzer.php
@@ -7,6 +7,7 @@ namespace Intervention\Image\Drivers\Vips\Analyzers;
 use Intervention\Image\Analyzers\PixelColorAnalyzer as GenericPixelColorAnalyzer;
 use Intervention\Image\Drivers\Vips\Core;
 use Intervention\Image\Exceptions\AnalyzerException;
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\StateException;
 use Intervention\Image\Interfaces\ColorInterface;
 use Intervention\Image\Interfaces\CoreInterface;
@@ -23,6 +24,7 @@ class PixelColorAnalyzer extends GenericPixelColorAnalyzer implements Specialize
      *
      * @throws StateException
      * @throws AnalyzerException
+     * @throws DriverException
      */
     public function analyze(ImageInterface $image): mixed
     {
@@ -39,6 +41,7 @@ class PixelColorAnalyzer extends GenericPixelColorAnalyzer implements Specialize
      *
      * @throws StateException
      * @throws AnalyzerException
+     * @throws DriverException
      */
     protected function colorAt(ImageInterface $image, CoreInterface $core, int $x, int $y): ColorInterface
     {

--- a/src/Analyzers/PixelColorsAnalyzer.php
+++ b/src/Analyzers/PixelColorsAnalyzer.php
@@ -6,6 +6,7 @@ namespace Intervention\Image\Drivers\Vips\Analyzers;
 
 use Intervention\Image\Collection;
 use Intervention\Image\Exceptions\AnalyzerException;
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\StateException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
@@ -19,6 +20,7 @@ class PixelColorsAnalyzer extends PixelColorAnalyzer implements SpecializedInter
      *
      * @throws StateException
      * @throws AnalyzerException
+     * @throws DriverException
      */
     public function analyze(ImageInterface $image): mixed
     {

--- a/src/Core.php
+++ b/src/Core.php
@@ -25,7 +25,34 @@ use Traversable;
  */
 class Core implements CoreInterface, Iterator
 {
+    /**
+     * Number of operations that may be chained onto the image before its
+     * pipeline is rendered into memory.
+     *
+     * libvips evaluates a pipeline by recursing once per node, on a worker
+     * thread whose stack is fixed when the thread is created. A long enough
+     * chain overruns that stack and takes the process down with SIGBUS or
+     * SIGSEGV, with no catchable error and nothing on stderr. The ceiling is
+     * the platform's default thread stack size, measured on a chain of
+     * composites at 198 nodes on macOS arm64, 1843 on musl and 2009 on glibc.
+     * Callers that build an image in a loop, tiling a watermark or drawing
+     * many shapes, reach it with ordinary inputs.
+     *
+     * Rendering to memory every N operations keeps the depth well under the
+     * lowest of those ceilings. Chains shorter than N, which is every normal
+     * use of the driver, never pay for it. Past N there is a cost: a rendered
+     * image is a whole image, so an operation that later narrows the region of
+     * interest, a crop after the chain say, no longer gets to narrow what the
+     * chain computes.
+     *
+     * This counts calls, not libvips nodes, so it is a bound rather than a
+     * measurement. A modifier that chains several nodes per call spends the
+     * budget faster than one node per call.
+     */
+    public const MAX_CHAINED_OPERATIONS = 32;
+
     protected int $iteratorIndex = 0;
+    protected int $chainedOperations = 0;
     protected CollectionInterface $meta;
     protected null|PathSource|BufferSource $stashedSource = null;
 
@@ -146,6 +173,7 @@ class Core implements CoreInterface, Iterator
      * @see CoreInterface::setNative()
      *
      * @throws InvalidArgumentException
+     * @throws DriverException
      */
     public function setNative(mixed $native): CoreInterface
     {
@@ -157,6 +185,16 @@ class Core implements CoreInterface, Iterator
 
         $this->vipsImage = $native;
         $this->stashedSource = null;
+
+        if (++$this->chainedOperations >= static::MAX_CHAINED_OPERATIONS) {
+            try {
+                $this->vipsImage = $this->vipsImage->copyMemory();
+            } catch (VipsException $e) {
+                throw new DriverException('Failed to render image pipeline into memory', previous: $e);
+            }
+
+            $this->chainedOperations = 0;
+        }
 
         return $this;
     }
@@ -185,6 +223,8 @@ class Core implements CoreInterface, Iterator
     /**
      * Renders vips image of given core into memory and serves any downstream
      * requests from the memory area
+     *
+     * @throws DriverException
      */
     public static function ensureInMemory(CoreInterface $core): CoreInterface
     {

--- a/src/Modifiers/BlurModifier.php
+++ b/src/Modifiers/BlurModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Modifiers;
 
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
@@ -18,6 +19,7 @@ class BlurModifier extends GenericBlurModifier implements SpecializedInterface
      * @see Intervention\Image\Interfaces\ModifierInterface::apply()
      *
      * @throws ModifierException
+     * @throws DriverException
      */
     public function apply(ImageInterface $image): ImageInterface
     {

--- a/src/Modifiers/BrightnessModifier.php
+++ b/src/Modifiers/BrightnessModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Modifiers;
 
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
@@ -18,6 +19,7 @@ class BrightnessModifier extends GenericBrightnessModifier implements Specialize
      * @see Intervention\Image\Interfaces\ModifierInterface::apply()
      *
      * @throws ModifierException
+     * @throws DriverException
      */
     public function apply(ImageInterface $image): ImageInterface
     {

--- a/src/Modifiers/ColorizeModifier.php
+++ b/src/Modifiers/ColorizeModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Modifiers;
 
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
@@ -18,6 +19,7 @@ class ColorizeModifier extends GenericColorizeModifier implements SpecializedInt
      * @see Intervention\Image\Interfaces\ModifierInterface::apply()
      *
      * @throws ModifierException
+     * @throws DriverException
      */
     public function apply(ImageInterface $image): ImageInterface
     {

--- a/src/Modifiers/ColorspaceModifier.php
+++ b/src/Modifiers/ColorspaceModifier.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers\Vips\Modifiers;
 
 use Intervention\Image\Drivers\Vips\ColorProcessor;
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Exceptions\NotSupportedException;
 use Intervention\Image\Interfaces\ImageInterface;
@@ -21,6 +22,7 @@ class ColorspaceModifier extends GenericColorspaceModifier implements Specialize
      *
      * @throws ModifierException
      * @throws NotSupportedException
+     * @throws DriverException
      */
     public function apply(ImageInterface $image): ImageInterface
     {

--- a/src/Modifiers/ContrastModifier.php
+++ b/src/Modifiers/ContrastModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Modifiers;
 
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
@@ -18,6 +19,7 @@ class ContrastModifier extends GenericContrastModifier implements SpecializedInt
      * @see Intervention\Image\Interfaces\ModifierInterface::apply()
      *
      * @throws ModifierException
+     * @throws DriverException
      */
     public function apply(ImageInterface $image): ImageInterface
     {

--- a/src/Modifiers/FillModifier.php
+++ b/src/Modifiers/FillModifier.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers\Vips\Modifiers;
 
 use Intervention\Image\Exceptions\ColorDecoderException;
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Exceptions\StateException;
 use Intervention\Image\Interfaces\ImageInterface;
@@ -24,6 +25,7 @@ class FillModifier extends GenericFillModifier implements SpecializedInterface
      *
      * @throws StateException
      * @throws ModifierException
+     * @throws DriverException
      */
     public function apply(ImageInterface $image): ImageInterface
     {

--- a/src/Modifiers/FillTransparentAreasModifier.php
+++ b/src/Modifiers/FillTransparentAreasModifier.php
@@ -72,6 +72,7 @@ class FillTransparentAreasModifier extends GenericFillTransparentAreasModifier i
      * @param array<float> $color
      * @throws StateException
      * @throws ModifierException
+     * @throws DriverException
      */
     private function canvas(ImageInterface $image, array $color): ImageInterface
     {

--- a/src/Modifiers/FlipModifier.php
+++ b/src/Modifiers/FlipModifier.php
@@ -6,6 +6,7 @@ namespace Intervention\Image\Drivers\Vips\Modifiers;
 
 use Intervention\Image\Direction;
 use Intervention\Image\Drivers\Vips\Core;
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
@@ -21,6 +22,7 @@ class FlipModifier extends GenericFlipModifier implements SpecializedInterface
      * @see Intervention\Image\Interfaces\ModifierInterface::apply()
      *
      * @throws ModifierException
+     * @throws DriverException
      */
     public function apply(ImageInterface $image): ImageInterface
     {

--- a/src/Modifiers/GammaModifier.php
+++ b/src/Modifiers/GammaModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Modifiers;
 
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
@@ -18,6 +19,7 @@ class GammaModifier extends GenericGammaModifier implements SpecializedInterface
      * @see Intervention\Image\Interfaces\ModifierInterface::apply()
      *
      * @throws ModifierException
+     * @throws DriverException
      */
     public function apply(ImageInterface $image): ImageInterface
     {

--- a/src/Modifiers/GrayscaleModifier.php
+++ b/src/Modifiers/GrayscaleModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Modifiers;
 
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
 use Intervention\Image\Modifiers\GrayscaleModifier as GenericGrayscaleModifier;
@@ -15,6 +16,8 @@ class GrayscaleModifier extends GenericGrayscaleModifier implements SpecializedI
      * {@inheritdoc}
      *
      * @see Intervention\Image\Interfaces\ModifierInterface::apply()
+     *
+     * @throws DriverException
      */
     public function apply(ImageInterface $image): ImageInterface
     {

--- a/src/Modifiers/InsertModifier.php
+++ b/src/Modifiers/InsertModifier.php
@@ -29,6 +29,17 @@ class InsertModifier extends GenericInsertModifier implements SpecializedInterfa
     public function apply(ImageInterface $image): ImageInterface
     {
         $watermark = $this->driver()->decodeImage($this->image);
+
+        // A libvips sequential source may only be read once, in order. The
+        // element is folded into the target's pipeline by reference, so it is
+        // read again every time that pipeline is evaluated: inserting the same
+        // decoded image twice, or encoding the result twice, fails with "out
+        // of order read". Materialising the element on its own core spends
+        // that single read here, and leaves every later evaluation reading
+        // from memory. Decoded images are shared by reference, so an image
+        // inserted many times only pays for this once.
+        Core::ensureInMemory($watermark->core());
+
         $elementNative = $watermark->core()->native();
         $position = $this->position($image, $watermark);
 

--- a/src/Modifiers/InvertModifier.php
+++ b/src/Modifiers/InvertModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Modifiers;
 
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
 use Intervention\Image\Modifiers\InvertModifier as GenericInvertModifier;
@@ -14,6 +15,8 @@ class InvertModifier extends GenericInvertModifier implements SpecializedInterfa
      * {@inheritdoc}
      *
      * @see Intervention\Image\Interfaces\ModifierInterface::apply()
+     *
+     * @throws DriverException
      */
     public function apply(ImageInterface $image): ImageInterface
     {

--- a/src/Modifiers/OrientModifier.php
+++ b/src/Modifiers/OrientModifier.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers\Vips\Modifiers;
 
 use Intervention\Image\Drivers\Vips\Core;
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
@@ -19,6 +20,7 @@ class OrientModifier extends GenericOrientModifier implements SpecializedInterfa
      * @see Intervention\Image\Interfaces\ModifierInterface::apply()
      *
      * @throws ModifierException
+     * @throws DriverException
      */
     public function apply(ImageInterface $image): ImageInterface
     {

--- a/src/Modifiers/ProfileModifier.php
+++ b/src/Modifiers/ProfileModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Modifiers;
 
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
@@ -18,6 +19,7 @@ class ProfileModifier extends GenericProfileModifier implements SpecializedInter
      * @see Intervention\Image\Interfaces\ModifierInterface::apply()
      *
      * @throws ModifierException
+     * @throws DriverException
      */
     public function apply(ImageInterface $image): ImageInterface
     {

--- a/src/Modifiers/ResizeModifier.php
+++ b/src/Modifiers/ResizeModifier.php
@@ -9,6 +9,7 @@ use Intervention\Image\Drivers\Vips\Core;
 use Intervention\Image\Drivers\Vips\Source\BufferSource;
 use Intervention\Image\Drivers\Vips\Source\PathSource;
 use Intervention\Image\Drivers\Vips\Traits\CanNormalizeBands;
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\InvalidArgumentException;
 use Intervention\Image\Interfaces\ColorspaceInterface;
 use Intervention\Image\Interfaces\ImageInterface;
@@ -30,6 +31,7 @@ class ResizeModifier extends GenericResizeModifier implements SpecializedInterfa
      *
      * @throws InvalidArgumentException
      * @throws VipsException
+     * @throws DriverException
      */
     public function apply(ImageInterface $image): ImageInterface
     {

--- a/src/Modifiers/ResolutionModifier.php
+++ b/src/Modifiers/ResolutionModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Modifiers;
 
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
 use Intervention\Image\Modifiers\ResolutionModifier as GenericResolutionModifier;
@@ -14,6 +15,8 @@ class ResolutionModifier extends GenericResolutionModifier implements Specialize
      * {@inheritdoc}
      *
      * @see Intervention\Image\Interfaces\ModifierInterface::apply()
+     *
+     * @throws DriverException
      */
     public function apply(ImageInterface $image): ImageInterface
     {

--- a/src/Modifiers/SharpenModifier.php
+++ b/src/Modifiers/SharpenModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Modifiers;
 
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
@@ -19,6 +20,7 @@ class SharpenModifier extends GenericSharpenModifier implements SpecializedInter
      * @see Intervention\Image\Interfaces\ModifierInterface::apply()
      *
      * @throws ModifierException
+     * @throws DriverException
      */
     public function apply(ImageInterface $image): ImageInterface
     {

--- a/src/Modifiers/StripMetaModifier.php
+++ b/src/Modifiers/StripMetaModifier.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers\Vips\Modifiers;
 
 use Intervention\Image\Collection;
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\ModifierInterface;
@@ -22,6 +23,7 @@ class StripMetaModifier implements ModifierInterface, SpecializedInterface
      * @see ModifierInterface::apply()
      *
      * @throws ModifierException
+     * @throws DriverException
      */
     public function apply(ImageInterface $image): ImageInterface
     {

--- a/src/Modifiers/TextModifier.php
+++ b/src/Modifiers/TextModifier.php
@@ -124,14 +124,7 @@ class TextModifier extends GenericTextModifier implements SpecializedInterface
 
             if (isset($stroke)) {
                 // draw stroke effect with offsets
-                foreach ($this->strokeOffsets($this->font) as $offset) {
-                    $modified = $this->placeTextOnFrame(
-                        $stroke,
-                        $modified,
-                        $blockPosition->x() - $offset->x(),
-                        $blockPosition->y() - $offset->y(),
-                    );
-                }
+                $modified = $this->placeStrokeOnFrame($stroke, $modified, $blockPosition);
             }
 
             // place text image on original image
@@ -150,14 +143,7 @@ class TextModifier extends GenericTextModifier implements SpecializedInterface
 
                 if (isset($stroke)) {
                     // draw stroke effect with offsets
-                    foreach ($this->strokeOffsets($this->font) as $offset) {
-                        $modifiedFrame = $this->placeTextOnFrame(
-                            $stroke,
-                            $modifiedFrame,
-                            $blockPosition->x() - $offset->x(),
-                            $blockPosition->y() - $offset->y(),
-                        );
-                    }
+                    $modifiedFrame = $this->placeStrokeOnFrame($stroke, $modifiedFrame, $blockPosition);
                 }
 
                 // place text image on original image
@@ -177,6 +163,44 @@ class TextModifier extends GenericTextModifier implements SpecializedInterface
         $image->core()->setNative($modified);
 
         return $image;
+    }
+
+    /**
+     * Stamp the stroke image around the given position on the given frame.
+     *
+     * A stroke of width w is (2w + 1)^2 stamps. Chaining one composite per
+     * stamp builds that many libvips pipeline nodes, and libvips recurses once
+     * per node when it evaluates, so a stroke of 6 or more overruns the worker
+     * thread stack on macOS and kills the process. libvips composites any
+     * number of overlays in a single operation, which is one node whatever the
+     * width, and a good deal faster.
+     */
+    private function placeStrokeOnFrame(
+        VipsImage $stroke,
+        FrameInterface $frame,
+        PointInterface $blockPosition,
+    ): FrameInterface {
+        $x = [];
+        $y = [];
+
+        foreach ($this->strokeOffsets($this->font) as $offset) {
+            $x[] = $blockPosition->x() - $offset->x();
+            $y[] = $blockPosition->y() - $offset->y();
+        }
+
+        if ($x === []) {
+            return $frame;
+        }
+
+        $frame->setNative(
+            $frame->native()->composite(
+                array_fill(0, count($x), $stroke),
+                array_fill(0, count($x), BlendMode::OVER),
+                ['x' => $x, 'y' => $y],
+            ),
+        );
+
+        return $frame;
     }
 
     /**

--- a/src/Modifiers/TrimModifier.php
+++ b/src/Modifiers/TrimModifier.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers\Vips\Modifiers;
 
 use Intervention\Image\Drivers\Vips\Core;
+use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Exceptions\NotSupportedException;
 use Intervention\Image\Interfaces\ImageInterface;
@@ -28,6 +29,7 @@ class TrimModifier extends GenericTrimModifier implements SpecializedInterface
      *
      * @throws NotSupportedException
      * @throws ModifierException
+     * @throws DriverException
      */
     public function apply(ImageInterface $image): ImageInterface
     {

--- a/tests/Unit/CoreTest.php
+++ b/tests/Unit/CoreTest.php
@@ -181,4 +181,70 @@ class CoreTest extends BaseTestCase
 
         $this->assertNull($core->stashedSource());
     }
+
+    public function testSetNativeLeavesThePipelineLazyBelowTheOperationLimit(): void
+    {
+        $core = new Core($this->vipsImage(10, 10, [255, 0, 0]));
+
+        $native = null;
+        for ($i = 1; $i < Core::MAX_CHAINED_OPERATIONS; $i++) {
+            $native = $this->vipsImage(10, 10, [$i, 0, 0]);
+            $core->setNative($native);
+        }
+
+        // untouched: the image handed over is the one that comes back
+        $this->assertSame($native, $core->native());
+    }
+
+    public function testSetNativeRendersThePipelineToMemoryAtTheOperationLimit(): void
+    {
+        $core = new Core($this->vipsImage(10, 10, [255, 0, 0]));
+
+        $native = null;
+        for ($i = 1; $i <= Core::MAX_CHAINED_OPERATIONS; $i++) {
+            $native = $this->vipsImage(10, 10, [$i, 0, 0]);
+            $core->setNative($native);
+        }
+
+        // rendered: a different instance, holding the last image handed over
+        $this->assertNotSame($native, $core->native());
+        $this->assertSame($native->writeToBuffer('.png'), $core->native()->writeToBuffer('.png'));
+    }
+
+    public function testSetNativeStartsANewBudgetAfterRenderingToMemory(): void
+    {
+        $core = new Core($this->vipsImage(10, 10, [255, 0, 0]));
+
+        // spend the whole budget, which renders on the last call
+        for ($i = 1; $i <= Core::MAX_CHAINED_OPERATIONS; $i++) {
+            $core->setNative($this->vipsImage(10, 10, [$i, 0, 0]));
+        }
+
+        // the budget is a period, not a threshold: the next call is lazy again
+        $native = $this->vipsImage(10, 10, [1, 0, 0]);
+        $core->setNative($native);
+
+        $this->assertSame($native, $core->native());
+    }
+
+    public function testChainedModificationsPastTheOperationLimitStillRender(): void
+    {
+        // Without the render-to-memory guard this chain overruns the libvips
+        // worker thread stack and kills the process. Where that happens
+        // depends on the platform's thread stack size: 1000 inserts is well
+        // past the ceiling measured on macOS, between 150 and 200, and well
+        // short of the one on glibc, over 6000. So on Linux CI this asserts
+        // only that rendering mid-chain leaves the result alone.
+        $manager = ImageManager::usingDriver(Driver::class);
+
+        $image = $manager->createImage(16, 16)->fill('0000ff');
+        $watermark = $manager->createImage(4, 4)->fill('ff0000');
+
+        for ($i = 0; $i < 1000; $i++) {
+            $image->insert($watermark);
+        }
+
+        $this->assertColor(255, 0, 0, 255, $image->colorAt(2, 2));
+        $this->assertColor(0, 0, 255, 255, $image->colorAt(10, 10));
+    }
 }

--- a/tests/Unit/Modifiers/InsertModifierTest.php
+++ b/tests/Unit/Modifiers/InsertModifierTest.php
@@ -6,6 +6,7 @@ namespace Intervention\Image\Drivers\Vips\Tests\Unit\Modifiers;
 
 use Intervention\Image\Drivers\Vips\Driver;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
+use Intervention\Image\Encoders\PngEncoder;
 use Intervention\Image\Encoders\WebpEncoder;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Modifiers\InsertModifier;
@@ -72,5 +73,23 @@ final class InsertModifierTest extends BaseTestCase
 
         $encoded = $image->encode(new WebpEncoder(quality: 80));
         $this->assertMediaType('image/webp', $encoded);
+    }
+
+    public function testApplyThenEncodeTwiceKeepsTheSameResult(): void
+    {
+        // Regression for: a watermark decoded from a file opens a sequential
+        // libvips source, which may only be read once, in order. It stays in
+        // the target's pipeline by reference, so encoding the result a second
+        // time read that source a second time and failed with "pngload: out
+        // of order read".
+        $manager = ImageManager::usingDriver(Driver::class);
+
+        $image = $manager->createImage(64, 64)->fill('0000ff');
+        $image->insert($manager->decodePath($this->getTestResourcePath('circle.png')));
+
+        $first = (string) $image->encode(new PngEncoder());
+        $second = (string) $image->encode(new PngEncoder());
+
+        $this->assertSame($first, $second);
     }
 }

--- a/tests/Unit/Modifiers/InsertModifierTest.php
+++ b/tests/Unit/Modifiers/InsertModifierTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Tests\Unit\Modifiers;
 
+use Intervention\Image\Drivers\Vips\Core;
 use Intervention\Image\Drivers\Vips\Driver;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
 use Intervention\Image\Encoders\PngEncoder;
@@ -91,5 +92,23 @@ final class InsertModifierTest extends BaseTestCase
         $second = (string) $image->encode(new PngEncoder());
 
         $this->assertSame($first, $second);
+    }
+
+    public function testApplyDecodedWatermarkPastThePipelineRenderLimitEncodes(): void
+    {
+        // Rendering the pipeline to memory mid-chain is another evaluation of
+        // the watermark's sequential source, on top of the one at encode time.
+        // Regression for the render limit and the element materialisation
+        // pulling against each other.
+        $manager = ImageManager::usingDriver(Driver::class);
+
+        $image = $manager->createImage(64, 64)->fill('0000ff');
+        $watermark = $manager->decodePath($this->getTestResourcePath('circle.png'));
+
+        for ($i = 0; $i <= Core::MAX_CHAINED_OPERATIONS; $i++) {
+            $image->insert($watermark);
+        }
+
+        $this->assertMediaType('image/png', $image->encode(new PngEncoder()));
     }
 }

--- a/tests/Unit/Modifiers/TextModifierTest.php
+++ b/tests/Unit/Modifiers/TextModifierTest.php
@@ -6,6 +6,7 @@ namespace Intervention\Image\Drivers\Vips\Tests\Unit\Modifiers;
 
 use Intervention\Image\Drivers\Vips\Modifiers\TextModifier;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
+use Intervention\Image\Encoders\PngEncoder;
 use Intervention\Image\Geometry\Point;
 use Intervention\Image\Typography\Font;
 
@@ -21,5 +22,22 @@ class TextModifierTest extends BaseTestCase
         $font->setAlignmentHorizontal('center');
         $font->setLineHeight(2);
         $image->modify(new TextModifier('ABC & D', new Point(150, 150), $font));
+    }
+
+    public function testApplyWideStroke(): void
+    {
+        // A stroke of width w is (2w + 1)^2 stamps. Chaining one composite per
+        // stamp overran the libvips worker thread stack and killed the process
+        // from width 6 up; they are composited in a single operation now.
+        $image = $this->readTestImage('blocks.png');
+        $font = new Font($this->getTestResourcePath('test.ttf'));
+        $font->setColor('b53517');
+        $font->setSize(32);
+        $font->setStrokeColor('ffffff');
+        $font->setStrokeWidth(10);
+
+        $image->modify(new TextModifier('ABC', new Point(150, 150), $font));
+
+        $this->assertMediaType('image/png', $image->encode(new PngEncoder()));
     }
 }


### PR DESCRIPTION
Deep chains of lazy operations kill the PHP process

A long enough chain of operations on a vips-backed image takes the whole process down with `SIGBUS` (exit 138) or `SIGSEGV`. No exception, no PHP error, nothing on stderr. It's not intermittent, and it doesn't depend on canvas size. It tracks the number of chained nodes.

Repro, no Intervention involved:

```php
$base = Image::black(64, 64)->add(128)->cast('uchar');
$base = $base->bandjoin([$base, $base])->copy(['interpretation' => 'srgb'])->copyMemory();
$tile = Image::black(8, 8)->add(255)->cast('uchar');
$tile = $tile->bandjoin([$tile, $tile, $tile])->copy(['interpretation' => 'srgb'])->copyMemory();

$out = $base;
for ($i = 0; $i < 400; $i++) {
    $out = $out->composite2($tile, BlendMode::OVER, ['x' => $i % 56, 'y' => ($i * 3) % 56]);
}
$out->writeToBuffer('.png');   // dies here
```

Where it dies, bisected with that exact script:

| platform | libvips | last depth that works |
| --- | --- | --- |
| macOS arm64 (Homebrew) | 8.18.5 | 198 |
| Alpine 3.22, musl | 8.16.1 | 1843 |
| Debian, glibc (this repo's Dockerfile) | 8.18.1 | 2009 |

Under lldb it faults on a thread named `libvips worker`, `EXC_BAD_ACCESS` on what looks like the stack guard page. The backtrace is one cycle of about 8 frames, repeated once per chained node:

```
vips_composite_base_gen -> vips_region_prepare_to -> vips_region_prepare_to_generate
  -> vips_region_generate -> vips_copy_gen -> vips_region_prepare -> vips_region_fill
  -> vips_region_generate -> vips_composite_base_gen -> ...
```

I think libvips recurses once per node when it evaluates, and a worker thread's stack is fixed when the thread is created, so the ceiling ends up being the platform's default thread stack size. `ulimit -s` doesn't move the macOS number, which would fit (worker threads get the pthread default, not `RLIMIT_STACK`). I can't vouch for libvips internals past what the backtrace shows, but the numbers move the way you'd expect if that's what's going on.

Which makes it a libvips property, not a bug in this driver. The driver can't stop a caller from chaining, but it can bound the depth. That's the third commit. The first two are separate bugs I ran into on the way, both reachable on `main` today.

`fix: read a decoded insert element only once`. A watermark decoded from a file or a buffer opens a sequential libvips source, readable once and in order. `InsertModifier` folds it into the target pipeline by reference, so it gets read again on every evaluation. Two ordinary things do that: inserting the same decoded image more than once, and encoding the result twice. Both fail on `main` with `pngload: out of order read`. The animated branch already worked around this per call, with a comment naming the same cause. This hoists it onto the element's own core, so it happens once instead of once per call.

`perf: composite the text stroke in a single operation`. A stroke of width w is (2w + 1)^2 stamps, and each one was chained as its own composite. On macOS a stroke of 6 or more kills the process. Width 10, the cap Intervention allows, is 441 stamps. libvips composites any number of overlays in one call, which is a single node whatever the width.

`fix: render the pipeline to memory past 32 chained operations`. `Core` counts the operations chained through `setNative()` and calls `copyMemory()` every 32.

What it costs:

| case | before | after |
| --- | --- | --- |
| `cover(800,300)` + jpeg85 (`bench/`) | 12.5 ms | 12.6 ms |
| decode 2000x1500 + one 50x50 PNG insert + jpeg85 | 14.6 ms | 15.1 ms |
| text stroke width 5, 400x120 | 16.9 ms | 8.8 ms |
| text stroke width 6 to 10 | SIGBUS | renders |
| tiled mark on 1200x900, 20px (depth 105) | 252 ms | 138 ms |
| tiled mark on 1200x900, 10px (depth 210) | SIGBUS | 185 ms |
| tiled mark on 1200x900, 5px (depth 420) | SIGBUS | 305 ms |

Output is identical wherever both sides complete, except the stroke. Compositing one overlay at a time rounds to uchar at every stamp, one call accumulates in premultiplied float and rounds once. Over the widths that used to work, the difference is at most 2/255 and only on antialiased edges: 64 to 109 pixels out of 16000, mean 0.003.

Caveats:

The counter counts calls, not libvips nodes. A modifier that chains several nodes per call burns through the budget faster, so 32 is a bound rather than a measurement. `TextModifier` was the extreme case at 225 nodes for one call, which is why it's fixed here instead of left to the guard.

Past 32 operations a rendered image is a whole image, so a `crop` at the end of a long chain no longer narrows what the chain computes. Below 32 nothing changes, and 32 covers every normal use I can think of.

`setNative()` can throw now, since the render can fail. `CoreInterface::setNative()` declares no exceptions, so PHPStan only caught one site by itself. I found the rest by adding `@throws` to the interface in a scratch tree and re-running, then declared them here. 19 sites, docblocks only. If you'd rather the interface carried it, tell me and I'll drop that part.

Testing: `docker compose run --rm tests` is green, 394 tests, and `analysis` and `standards` too. I reverted each fix in turn to check its test actually fails. One exception, the 1000-insert chain test only crashes where the stack is small, so on Linux CI it asserts that rendering mid-chain leaves the result alone and nothing else. Reaching the glibc ceiling from a test isn't portable, and it would kill the runner instead of reporting a failure.

Unrelated, but so you know it's not me: on macOS `FontProcessorTest::testBoxSizeTtf` fails before and after these commits, 241 against an expected 155. Probably a font stack difference.

