### PR TITLE
fix(modifiers): rotate 16-bit sources at non-quarter angles

### DIFF
--- a/src/Modifiers/RotateModifier.php
+++ b/src/Modifiers/RotateModifier.php
@@ -13,9 +13,16 @@ use Intervention\Image\Interfaces\SpecializedInterface;
 use Intervention\Image\Modifiers\RotateModifier as GenericRotateModifier;
 use Jcupitt\Vips\Exception as VipsException;
 use Jcupitt\Vips\Image as VipsImage;
+use Jcupitt\Vips\Interpretation;
 
 class RotateModifier extends GenericRotateModifier implements SpecializedInterface
 {
+    /**
+     * Angles served by rot90/rot180/rot270. They expose no new area and
+     * therefore paint no background, unlike the similarity() fallback.
+     */
+    private const ANGLES_WITHOUT_BACKGROUND = [0.0, 90.0, -270.0, 180.0, -180.0, -90.0, 270.0];
+
     /**
      * {@inheritdoc}
      *
@@ -27,19 +34,31 @@ class RotateModifier extends GenericRotateModifier implements SpecializedInterfa
      */
     public function apply(ImageInterface $image): ImageInterface
     {
-        $backgroundColor = $this->driver()
-            ->colorProcessor($image)
-            ->export($this->backgroundColor());
-
         // rot90/rot180/rot270/similarity require non-sequential reads of the
         // source. Sequentially-decoded sources fail with `out of order read`
         // when the encoder later walks the pipeline.
         Core::ensureInMemory($image->core());
 
+        $angle = $this->rotationAngle();
+
+        // similarity() needs an alpha channel to paint the areas it exposes.
+        // Sources that decode to three bands (NativeObjectDecoder only adds
+        // the channel to SRGB sources, so 16-bit ones keep three bands) get
+        // theirs here, before the background color is exported, so that the
+        // exported vector is sized to the bandcount similarity() will see.
+        if (!in_array($angle, self::ANGLES_WITHOUT_BACKGROUND, true)) {
+            $this->addAlpha($image);
+        }
+
+        $backgroundColor = $this->scaleToImage(
+            $this->driver()->colorProcessor($image)->export($this->backgroundColor()),
+            $image->core()->native(),
+        );
+
         $frames = [];
         foreach ($image as $frame) {
             try {
-                $native = match ($this->rotationAngle()) {
+                $native = match ($angle) {
                     0.0 => $frame->native(),
                     90.0, -270.0 => $frame->native()->rot90(),
                     180.0, -180.0 => $frame->native()->rot180(),
@@ -68,13 +87,63 @@ class RotateModifier extends GenericRotateModifier implements SpecializedInterfa
      */
     private function rotate(VipsImage $vipsImage, array $backgroundColor): VipsImage
     {
-        if (!$vipsImage->hasAlpha()) {
-            $vipsImage = $vipsImage->bandjoin_const(255);
-        }
-
         return $vipsImage->similarity([
             'angle' => $this->rotationAngle(), // TODO: check rotation direction
             'background' => $backgroundColor,
         ]);
+    }
+
+    /**
+     * Add an alpha channel to the given image unless it already carries one.
+     *
+     * addalpha() picks the opaque value that goes with the interpretation of
+     * the image, where a hardcoded 255 would leave 16-bit sources all but
+     * fully transparent.
+     *
+     * @throws ModifierException
+     */
+    private function addAlpha(ImageInterface $image): void
+    {
+        $vipsImage = $image->core()->native();
+
+        try {
+            if ($vipsImage->hasAlpha()) {
+                return;
+            }
+
+            $image->core()->setNative($vipsImage->addalpha());
+        } catch (VipsException $e) {
+            throw new ModifierException(
+                'Failed to apply ' . self::class . ', unable to add alpha channel',
+                previous: $e,
+            );
+        }
+    }
+
+    /**
+     * Scale the exported color to the value range of the given image.
+     *
+     * ColorProcessor::export() returns channel values on a 0-255 scale, but
+     * libvips reads the background of similarity() on the scale that goes
+     * with the interpretation of the image: 0-65535 for 16-bit sources and
+     * 0-1 for scRGB ones. The ranges below are the ones libvips itself uses
+     * to pick an opaque alpha value in addalpha().
+     *
+     * @param array<float> $color
+     * @return array<float>
+     */
+    private function scaleToImage(array $color, VipsImage $vipsImage): array
+    {
+        $max = match ($vipsImage->interpretation) {
+            Interpretation::RGB16, Interpretation::GREY16 => 65535,
+            Interpretation::SCRGB => 1,
+            default => 255,
+        };
+
+        if ($max === 255) {
+            return $color;
+        }
+
+        return array_map(fn(float $value): float => $value / 255 * $max, $color);
     }
 }

--- a/tests/Unit/Modifiers/RotateModifierTest.php
+++ b/tests/Unit/Modifiers/RotateModifierTest.php
@@ -9,9 +9,13 @@ use Intervention\Image\Drivers\Vips\Decoders\BinaryImageDecoder;
 use Intervention\Image\Drivers\Vips\Driver;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
 use Intervention\Image\Encoders\JpegEncoder;
+use Intervention\Image\Encoders\PngEncoder;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Modifiers\RotateModifier;
+use Jcupitt\Vips\BandFormat;
+use Jcupitt\Vips\Exception as VipsException;
 use Jcupitt\Vips\Image as VipsImage;
+use Jcupitt\Vips\Interpretation;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(RotateModifier::class)]
@@ -101,5 +105,75 @@ final class RotateModifierTest extends BaseTestCase
 
         $bytes = $image->encode(new JpegEncoder(quality: 75))->toString();
         $this->assertNotEmpty($bytes);
+    }
+
+    /**
+     * Regression: sources that decode to three bands without an alpha channel
+     * threw `linear: vector must have 1 or 4 elements`. The background color is
+     * exported against the three-band image, but the rotation then adds an
+     * alpha band and hands the stale three-element vector to similarity().
+     *
+     * 16-bit PNG/TIFF sources are the practical way to get there: the decoder
+     * only normalizes to four bands when the interpretation is SRGB, and a
+     * 16-bit source loads as RGB16.
+     */
+    public function testRotateSixteenBitSource(): void
+    {
+        $image = (new Driver())->decodeImage(self::sixteenBitPng(), [BinaryImageDecoder::class]);
+        $image->modify(new RotateModifier(45, 'fff'));
+
+        $rotated = VipsImage::newFromBuffer($image->encode(new PngEncoder())->toString());
+
+        $this->assertEquals(BandFormat::USHORT, $rotated->format);
+        $this->assertTrue($rotated->hasAlpha());
+
+        // the exposed corner has to be opaque white on the 16-bit scale, not
+        // the 255 that ColorProcessor::export() hands out
+        $this->assertEquals([65535, 65535, 65535, 65535], $rotated->getpoint(0, 0));
+    }
+
+    /**
+     * The alpha channel of the background color survives the rotation of a
+     * three-band source, instead of being dropped when the vector is sized to
+     * the bandcount of the image before the alpha band is added.
+     */
+    public function testRotateSixteenBitSourceKeepsBackgroundAlpha(): void
+    {
+        $image = (new Driver())->decodeImage(self::sixteenBitPng(), [BinaryImageDecoder::class]);
+        $image->modify(new RotateModifier(45, 'ffffff00'));
+
+        $rotated = VipsImage::newFromBuffer($image->encode(new PngEncoder())->toString());
+
+        $this->assertEquals(0, $rotated->getpoint(0, 0)[3]);
+    }
+
+    /**
+     * Quarter turns take the rot90/rot180/rot270 path, which paints no
+     * background and must not gain an alpha band.
+     */
+    public function testRotateSixteenBitSourceQuarterTurn(): void
+    {
+        $image = (new Driver())->decodeImage(self::sixteenBitPng(), [BinaryImageDecoder::class]);
+        $image->modify(new RotateModifier(90, 'fff'));
+
+        $rotated = VipsImage::newFromBuffer($image->encode(new PngEncoder())->toString());
+
+        $this->assertEquals(BandFormat::USHORT, $rotated->format);
+        $this->assertFalse($rotated->hasAlpha());
+    }
+
+    /**
+     * 16-bit RGB PNG, the source shape reported in the issue: three bands,
+     * ushort, RGB16 interpretation.
+     *
+     * @throws VipsException
+     */
+    private static function sixteenBitPng(): string
+    {
+        return VipsImage::black(32, 32, ['bands' => 3])
+            ->add(30000)
+            ->cast(BandFormat::USHORT)
+            ->copy(['interpretation' => Interpretation::RGB16])
+            ->writeToBuffer('.png', ['bitdepth' => 16]);
     }
 }


### PR DESCRIPTION
Rotating a 16-bit PNG or TIFF at anything other than 0/90/180/270 throws.

Repro:

```php
use Intervention\Image\Drivers\Vips\Driver;
use Intervention\Image\ImageManager;
use Jcupitt\Vips\Image as VipsImage;

$png = VipsImage::black(32, 32, ['bands' => 3])
    ->add(30000)
    ->cast('ushort')
    ->copy(['interpretation' => 'rgb16'])
    ->writeToBuffer('.png', ['bitdepth' => 16]);

ImageManager::usingDriver(Driver::class)->decodeBinary($png)->rotate(10);
```

```
ModifierException: Failed to apply ...\Vips\Modifiers\RotateModifier, unable to rotate image
Caused by: Jcupitt\Vips\Exception: libvips error: linear: vector must have 1 or 4 elements
```

Repro'd on libvips 8.18.1 (the version in the repo `Dockerfile`) and on 8.18.5 locally, with `intervention/image` 4.2.1.

What happens: `apply()` exports the background color against the image, which has three bands, so `ColorProcessor::export()` truncates the vector to three elements. `rotate()` then calls `bandjoin_const(255)` and hands that stale three-element vector to `similarity()` on a now four-band image.

8-bit sources never get there, because `NativeObjectDecoder` bandjoins them to four bands on decode, but only when the interpretation is `srgb`. A 16-bit source loads as `rgb16` and keeps its three bands. Quarter turns are fine, they take the `rot90`/`rot180`/`rot270` path and paint no background at all.

What I measured before the patch:

| source | decoded | `rotate(90)` | `rotate(10)` |
| --- | --- | --- | --- |
| PNG 8-bit RGB | 4 / uchar / srgb | ok | ok |
| PNG 8-bit RGBA | 4 / uchar / srgb | ok | ok |
| PNG 8-bit grey | 4 / uchar / srgb | ok | ok |
| PNG 16-bit RGB | 3 / ushort / rgb16 | ok | throws |
| PNG 16-bit RGBA | 4 / ushort / rgb16 | ok | ok |
| PNG 16-bit grey | 3 / ushort / rgb16 | ok | throws |
| TIFF 16-bit RGB | 3 / ushort / rgb16 | ok | throws |

The fix adds the alpha band before the color is exported, so the exported vector is sized to what `similarity()` actually sees. It also keeps the alpha channel of the background color, which the truncation was dropping. Two other things had to come with it:

- `bandjoin_const(255)` becomes `addalpha()`. On a `ushort` image 255 is about 0.4% opacity, so fixing only the vector length would have produced a nearly invisible image.
- the exported color gets scaled to the value range of the image. `export()` always returns 0-255, and 255 on a 16-bit image paints near black instead of white. I used the same ranges libvips uses to pick an opaque alpha in `addalpha()` (65535 for `rgb16` and `grey16`, 1 for `scrgb`), so the added band and the background agree.

After the patch a 16-bit rotation matches the 8-bit one, translucent backgrounds included (corner pixel exposed by `rotate(45)`):

| background | 8-bit | 16-bit |
| --- | --- | --- |
| `fff` | `[255,255,255,255]` | `[65535,65535,65535,65535]` |
| `ffffff00` | `[0,0,0,0]` | `[0,0,0,0]` |
| `ff000080` | `[255,0,0,128]` | `[65535,0,0,32896]` |

Three regression tests added: an arbitrary angle, an arbitrary angle with a translucent background, and a quarter turn that must not gain an alpha band. Full suite, phpstan and phpcs all pass in the Docker setup.

One thing I deliberately left out: the 0-255 scale in `ColorProcessor::export()` is not specific to rotation. `FillModifier` and `ContainModifier` paint near black on 16-bit sources for the same reason, `fill('ff0000')` gives `[255,0,0]` where the image range is 0-65535. My guess is it should be fixed in `ColorProcessor` itself, but that touches every modifier, so I kept it out of here. Happy to open a separate issue or PR for it if you want.
