### PR TITLE
fix(modifiers): keep the trimmed area when a later corner matches it

### DIFF
--- a/src/Modifiers/TrimModifier.php
+++ b/src/Modifiers/TrimModifier.php
@@ -39,6 +39,8 @@ class TrimModifier extends GenericTrimModifier implements SpecializedInterface
 
         $core = Core::ensureInMemory($image->core());
         $native = $core->native();
+        $width = $native->width;
+        $height = $native->height;
         $maxThreshold = match ($image->core()->native()->format) {
             BandFormat::USHORT => 65535,
             BandFormat::FLOAT => 1,
@@ -52,16 +54,23 @@ class TrimModifier extends GenericTrimModifier implements SpecializedInterface
                     'background' => $point,
                 ]);
 
-                $native = $native->crop(
-                    min($trim['left'], $image->width() - 1),
-                    min($trim['top'], $image->height() - 1),
-                    max($trim['width'], 1),
-                    max($trim['height'], 1),
-                );
-
+                // An empty box means the whole remaining image matches the background color of
+                // the current corner. The corner colors are read from the original image, so a
+                // later corner may well match an area that an earlier corner has already
+                // isolated. That area is content and must be kept.
                 if ($trim['width'] === 0 || $trim['height'] === 0) {
+                    if ($native->width < $width || $native->height < $height) {
+                        continue;
+                    }
+
+                    // Nothing but background left. Return a single pixel, which is what the
+                    // other drivers do in this case.
+                    $native = $native->crop(0, 0, 1, 1);
+
                     break;
                 }
+
+                $native = $native->crop($trim['left'], $trim['top'], $trim['width'], $trim['height']);
             } catch (VipsException $e) {
                 throw new ModifierException('Failed to trim image', previous: $e);
             }

--- a/tests/Unit/Modifiers/TrimModifierTest.php
+++ b/tests/Unit/Modifiers/TrimModifierTest.php
@@ -4,9 +4,15 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Tests\Unit\Modifiers;
 
+use Intervention\Image\Drivers\Vips\Driver;
 use Intervention\Image\Drivers\Vips\Modifiers\TrimModifier;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
 use Intervention\Image\Exceptions\NotSupportedException;
+use Intervention\Image\Geometry\Point;
+use Intervention\Image\Geometry\Rectangle;
+use Intervention\Image\ImageManager;
+use Intervention\Image\Interfaces\ImageInterface;
+use Intervention\Image\Modifiers\DrawRectangleModifier;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(TrimModifier::class)]
@@ -55,5 +61,37 @@ final class TrimModifierTest extends BaseTestCase
         $image = $this->readTestImage('animation.gif');
         $this->expectException(NotSupportedException::class);
         $image->modify(new TrimModifier());
+    }
+
+    public function testTrimWithDifferentCornerColors(): void
+    {
+        $image = $this->cornerTestImage();
+        $this->assertEquals('ffffff', $image->colorAt(0, 0)->toHex());
+        $this->assertEquals('ff0000', $image->colorAt(119, 119)->toHex());
+
+        $image->modify(new TrimModifier());
+
+        $this->assertEquals(70, $image->width());
+        $this->assertEquals(70, $image->height());
+        $this->assertEquals('ff0000', $image->colorAt(0, 0)->toHex());
+    }
+
+    /**
+     * Create a 120x120 image with a white border area and a red block in the
+     * lower right corner, so that three corners are white and one is red.
+     */
+    private function cornerTestImage(): ImageInterface
+    {
+        $image = ImageManager::usingDriver(Driver::class)->createImage(120, 120);
+
+        $background = new Rectangle(120, 120, new Point(0, 0));
+        $background->setBackgroundColor('ffffff');
+        $image->modify(new DrawRectangleModifier($background));
+
+        $block = new Rectangle(70, 70, new Point(50, 50));
+        $block->setBackgroundColor('ff0000');
+        $image->modify(new DrawRectangleModifier($block));
+
+        return $image;
     }
 }


### PR DESCRIPTION
`trim()` throws instead of trimming when the four corner pixels are not the same color.

Repro: a 120x120 image, white on the top 50 rows and the left 50 columns, red everywhere else. Three corners white, one red. Then `->trim()`.

```
ModifierException: Failed to trim image
  previous: Jcupitt\Vips\Exception: libvips error: extract_area: bad extract area
```

What the loop does on that image:

```
iter 0  bg=[255,255,255]  native=120x120  find_trim={50,50,70,70}  -> crop, native is 70x70 now
iter 1  bg=[255,255,255]  native=70x70    find_trim={0,0,70,70}    -> no-op
iter 2  bg=[255,255,255]  native=70x70    find_trim={0,0,70,70}    -> no-op
iter 3  bg=[255,0,0]      native=70x70    find_trim={70,70,0,0}    -> crop(70,70,1,1) on a 70x70
```

The corner colors are read once on the original image, but the crops are cumulative. By the fourth corner the native is all red, so `find_trim` gets asked to trim red out of an all red image. It returns an empty box at the far corner, `{left: 70, top: 70, width: 0, height: 0}`.

Two things go wrong then. The crop runs before the `width === 0` check, so the empty box gets used before it is detected. And the clamp reads `$image->width()`, which is still 119 because it is never refreshed after the earlier crops. Wrong canvas, so `crop(70, 70, 1, 1)` goes through on a 70x70 native.

So I check the empty box before the crop instead. If an earlier corner already trimmed something, what is left is content and the original corner colors do not describe it anymore, so I skip that corner. If nothing was trimmed yet, the image is background everywhere and I return a 1x1, like gd does (`imagecropauto` returns false and the driver builds a 1x1) and imagick. I kept the 1x1 on purpose, `testTrimHighTolerance` asserts it, and there is a comment in the gd driver saying imagick does the same. The clamps are gone with it, `find_trim` always returns a box inside the native it measured.

On the repro the driver returns 70x70 now, same as imagick. gd returns 120x120, that is its corner averaging.

Adds a regression test for the disagreeing corners. Tested with libvips 8.18.5, ext vips 1.0.13, PHP 8.3.
