### PR TITLE
fix(modifiers): convert pixel data in ColorspaceModifier

### DIFF
--- a/src/ColorProcessor.php
+++ b/src/ColorProcessor.php
@@ -136,7 +136,11 @@ class ColorProcessor implements ColorProcessorInterface
             Cmyk::class => $this->colorspace->colorFromNormalized($normalized),
             Rgb::class => $this->colorspace->colorFromNormalized($normalized),
             Hsl::class => Rgb::colorFromNormalized($normalized)->toColorspace(Hsl::class),
-            Hsv::class => Rgb::colorFromNormalized($normalized)->toColorspace(Hsv::class),
+            // hsv is the only one of these with a vips interpretation of its
+            // own, so the bands already hold h/s/v and reading them as rgb
+            // would convert a second time. The others are mapped to srgb by
+            // colorspaceToInterpretation() and do need the conversion.
+            Hsv::class => $this->colorspace->colorFromNormalized($normalized),
             Oklab::class => Rgb::colorFromNormalized($normalized)->toColorspace(Oklab::class),
             Oklch::class => Rgb::colorFromNormalized($normalized)->toColorspace(Oklch::class),
             default => throw new NotSupportedException(

--- a/src/Modifiers/ColorspaceModifier.php
+++ b/src/Modifiers/ColorspaceModifier.php
@@ -34,8 +34,11 @@ class ColorspaceModifier extends GenericColorspaceModifier implements Specialize
         try {
             // colourspace() converts the pixel data, unlike copy() with a new
             // interpretation, which only re-labels the bands and leaves the
-            // image itself untouched. Converting a cmyk source drops its
-            // fourth band, so the alpha band has to be restored afterwards.
+            // image itself untouched. A cmyk source has no alpha band, its
+            // fourth band is k, so converting it to rgb gives three bands and
+            // the opaque alpha the rest of the pipeline expects is added back.
+            // Sources that do carry alpha keep it, colourspace() passes the
+            // bands beyond the source interpretation through untouched.
             $native = $this->normalizeBands(
                 $image->core()->native()->colourspace($interpretation),
             );

--- a/src/Modifiers/ColorspaceModifier.php
+++ b/src/Modifiers/ColorspaceModifier.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers\Vips\Modifiers;
 
 use Intervention\Image\Drivers\Vips\ColorProcessor;
+use Intervention\Image\Drivers\Vips\Traits\CanNormalizeBands;
 use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Exceptions\NotSupportedException;
@@ -15,6 +16,8 @@ use Jcupitt\Vips\Exception as VipsException;
 
 class ColorspaceModifier extends GenericColorspaceModifier implements SpecializedInterface
 {
+    use CanNormalizeBands;
+
     /**
      * {@inheritdoc}
      *
@@ -26,12 +29,16 @@ class ColorspaceModifier extends GenericColorspaceModifier implements Specialize
      */
     public function apply(ImageInterface $image): ImageInterface
     {
+        $interpretation = ColorProcessor::colorspaceToInterpretation($this->targetColorspace());
+
         try {
-            $native = $image->core()->native()->copy([
-                'interpretation' => ColorProcessor::colorspaceToInterpretation(
-                    $this->targetColorspace(),
-                ),
-            ]);
+            // colourspace() converts the pixel data, unlike copy() with a new
+            // interpretation, which only re-labels the bands and leaves the
+            // image itself untouched. Converting a cmyk source drops its
+            // fourth band, so the alpha band has to be restored afterwards.
+            $native = $this->normalizeBands(
+                $image->core()->native()->colourspace($interpretation),
+            );
         } catch (VipsException $e) {
             throw new ModifierException('Failed to modify image colorspace', previous: $e);
         }

--- a/tests/Unit/Modifiers/ColorspaceModifierTest.php
+++ b/tests/Unit/Modifiers/ColorspaceModifierTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers\Vips\Tests\Unit\Modifiers;
 
 use Intervention\Image\Colors\Cmyk\Colorspace as CmykColorspace;
+use Intervention\Image\Colors\Hsv\Colorspace as HsvColorspace;
 use Intervention\Image\Colors\Rgb\Channels\Alpha;
 use Intervention\Image\Colors\Rgb\Colorspace as RgbColorspace;
 use Intervention\Image\Drivers\Vips\Core;
@@ -54,12 +55,31 @@ final class ColorspaceModifierTest extends BaseTestCase
 
     public function testColorChangeToCmyk(): void
     {
+        // createTestImage() is opaque red with an alpha band
         $image = $this->createTestImage(8, 8);
         $this->assertEquals(RgbColorspace::class, $image->colorspace()::class);
+        $this->assertEquals('rgb(255 0 0)', $image->colorAt(0, 0)->toString());
 
         $image->modify(new ColorspaceModifier(CmykColorspace::class));
 
         $this->assertEquals(CmykColorspace::class, $image->colorspace()::class);
         $this->assertEquals(Interpretation::CMYK, $image->core()->native()->interpretation);
+
+        // the ink bands have to hold the converted values rather than the
+        // original rgb ones, and the alpha band of the source is kept
+        $this->assertEquals('cmyk(0 100 100 0)', $image->colorAt(0, 0)->toString());
+        $this->assertEquals(5, $image->core()->native()->bands);
+    }
+
+    public function testColorChangeToHsvIsReadBackInHsv(): void
+    {
+        $image = $this->createTestImage(8, 8);
+
+        $image->modify(new ColorspaceModifier(HsvColorspace::class));
+
+        // the bands hold h/s/v after the conversion, so reading them back must
+        // not run the rgb to hsv conversion a second time
+        $this->assertEquals(Interpretation::HSV, $image->core()->native()->interpretation);
+        $this->assertEquals('hsv(0 100% 100%)', $image->colorAt(0, 0)->toString());
     }
 }

--- a/tests/Unit/Modifiers/ColorspaceModifierTest.php
+++ b/tests/Unit/Modifiers/ColorspaceModifierTest.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers\Vips\Tests\Unit\Modifiers;
 
 use Intervention\Image\Colors\Cmyk\Colorspace as CmykColorspace;
+use Intervention\Image\Colors\Rgb\Channels\Alpha;
 use Intervention\Image\Colors\Rgb\Colorspace as RgbColorspace;
+use Intervention\Image\Drivers\Vips\Core;
+use Intervention\Image\Drivers\Vips\Driver;
 use Intervention\Image\Drivers\Vips\Modifiers\ColorspaceModifier;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
+use Intervention\Image\Image;
+use Jcupitt\Vips\Interpretation;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(ColorspaceModifier::class)]
@@ -19,5 +24,42 @@ final class ColorspaceModifierTest extends BaseTestCase
         $this->assertEquals(CmykColorspace::class, $image->colorspace()::class);
         $image->modify(new ColorspaceModifier(RgbColorspace::class));
         $this->assertEquals(RgbColorspace::class, $image->colorspace()::class);
+    }
+
+    public function testColorChangeConvertsPixelData(): void
+    {
+        // build a cmyk source from a known rgb color, so that converting it
+        // back has to land on the original color again
+        $native = self::vipsImage(8, 8, [205, 35, 56])->colourspace(Interpretation::CMYK);
+        $image = new Image(new Driver(), new Core($native));
+
+        $image->modify(new ColorspaceModifier(RgbColorspace::class));
+
+        $this->assertColor(205, 35, 56, 255, $image->colorAt(0, 0), tolerance: 8);
+    }
+
+    public function testColorChangeFromCmykRestoresAlphaBand(): void
+    {
+        // a cmyk source has no alpha band, so converting it to rgb has to
+        // re-add one to keep the bandcount the rest of the pipeline expects
+        $image = $this->readTestImage('cmyk.jpg');
+        $this->assertEquals(4, $image->core()->native()->bands);
+
+        $image->modify(new ColorspaceModifier(RgbColorspace::class));
+
+        $this->assertEquals(Interpretation::SRGB, $image->core()->native()->interpretation);
+        $this->assertEquals(4, $image->core()->native()->bands);
+        $this->assertEquals(255, $image->colorAt(0, 0)->channel(Alpha::class)->value());
+    }
+
+    public function testColorChangeToCmyk(): void
+    {
+        $image = $this->createTestImage(8, 8);
+        $this->assertEquals(RgbColorspace::class, $image->colorspace()::class);
+
+        $image->modify(new ColorspaceModifier(CmykColorspace::class));
+
+        $this->assertEquals(CmykColorspace::class, $image->colorspace()::class);
+        $this->assertEquals(Interpretation::CMYK, $image->core()->native()->interpretation);
     }
 }


### PR DESCRIPTION
`ColorspaceModifier` does not convert anything, it only re-tags the image:

```php
$native = $image->core()->native()->copy([
    'interpretation' => ColorProcessor::colorspaceToInterpretation($this->targetColorspace()),
]);
```

On a 4 band CMYK raster that leaves the bands where they were and calls them sRGB, so C/M/Y become R/G/B and K becomes alpha. The picture is destroyed, silently.

Repro on `tests/resources/cmyk.jpg`, pixel (0,0):

```
raw cmyk bands:               [12,149,18,0]
after ->setColorspace(Rgb):   rgb(12 149 18 / 0)    # fully transparent
native colourspace(SRGB):     rgb(235 135 173)
```

Same on a flat `#00ff00` CMYK JPEG, `rgb(255 0 254 / 0)` instead of `rgb(0 143 64)`. The Imagick modifier does the real conversion and the GD one is an honest no-op, so vips is the odd one out.

The fix uses `colourspace()`. I looked at `libvips/colour/colourspace.c` at `v8.17.2` and the CMYK routes are already in the table, both directions, so both libvips versions in the CI matrix are covered and there is no need for `icc_transform` with an explicit profile.

One thing had to come with it. `colourspace()` returns 3 bands from a CMYK source and `NativeObjectDecoder` gives everything else 4, so `insert()` afterwards failed with "images must have the same number of bands". `CanNormalizeBands` already does that bandjoin for `ResizeModifier` and `CoverModifier`, so I reused it.

After the patch:

```
insert() after setColorspace:   ok, bands=4
cmyk.jpg -> Rgb:                rgb(235 135 173), bands=4
flat #00ff00 cmyk -> Rgb:       rgb(0 143 64)      # same as a plain encode
```

I also checked an already sRGB source (no-op, unchanged), `animation.gif` (8 frames and `page-height` preserved, still encodes), a grayscale source, and a JPEG encode after the conversion.

One thing the conversion exposed. `ColorProcessor::import()` read the native bands as rgb and converted them to hsv, which was accidentally right while the modifier only re-labelled and left rgb pixels in place. Now that the raster really holds h/s/v it converts twice, `colorAt()` answered `hsv(172 45% 100%)` where the pixel is `hsv(196 100% 94%)`. `export()` already emitted genuine hsv, so the two were inverted. That is the second commit here. `Hsl`, `Oklab` and `Oklch` are unaffected, they map to sRGB so they still need the conversion.

The existing `testColorChange` only asserted the colorspace label, so it passed with the bug. Same for the sRGB to CMYK test I first wrote, the old `copy()` also produced `interpretation=cmyk`, so I reworked it to assert the ink values and the band count. Tests now cover the rgb to cmyk to rgb roundtrip, the alpha band restore, the ink values in the to-CMYK direction, and the hsv read back. Full suite, phpstan and phpcs pass.

Two consequences worth knowing about, neither of which I fixed here.

sRGB to CMYK goes through libvips' built-in CMYK profile and libvips attaches it, all 961644 bytes of it. On `test.jpg` that takes the encoded JPEG from 4617 to 966531 bytes. `strip: true` does not drop it, only `removeProfile()` does. It is the honest result of a real ICC conversion rather than a relabel, but it is a big surprise for anyone calling `setColorspace(Cmyk::class)` before an encode, so it may deserve a decision at the encoder level.

Converting an image that carries alpha to CMYK gives 5 bands (4 ink plus alpha) where the relabel gave 4. That shape looks supported, `ColorProcessor` handles 5 values and `JpegEncoder` already has a `count($bgColor) === 5` branch. It does change which `insert()` calls work, though. Inserting an element with no alpha into a multi band base already fails on `develop` ("images must have the same number of bands"), it just happened to line up at 4 bands against a relabelled CMYK base. So this is not a new failure in `insert()`, but the band count it sees changed.

One thing I left out: `ColorProcessor::colorspaceToInterpretation()` falls back to `SRGB` for `Hsl`, `Oklab` and `Oklch`, so asking for those silently gives you sRGB. Probably worth fixing too, but that mapping is also used by `thumbnailExportProfile()` so I kept it out of here.
