### PR TITLE
fix(modifiers): keep the colorspace of the source in grayscale

### DIFF
--- a/src/Modifiers/GrayscaleModifier.php
+++ b/src/Modifiers/GrayscaleModifier.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers\Vips\Modifiers;
 
 use Intervention\Image\Exceptions\DriverException;
+use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
 use Intervention\Image\Modifiers\GrayscaleModifier as GenericGrayscaleModifier;
+use Jcupitt\Vips\Exception as VipsException;
 use Jcupitt\Vips\Interpretation;
 
 class GrayscaleModifier extends GenericGrayscaleModifier implements SpecializedInterface
@@ -18,18 +20,34 @@ class GrayscaleModifier extends GenericGrayscaleModifier implements SpecializedI
      * @see Intervention\Image\Interfaces\ModifierInterface::apply()
      *
      * @throws DriverException
+     * @throws ModifierException
      */
     public function apply(ImageInterface $image): ImageInterface
     {
-        // turn image to grayscale
-        $image->core()->setNative(
-            $image->core()->native()->colourspace(Interpretation::B_W),
-        );
+        // grayscale is a color operation and is not meant to move the image to
+        // another colorspace, so the b-w detour has to end back where it
+        // started
+        $interpretation = $image->core()->native()->interpretation;
 
-        // return to srgb colorspace with grayscale image
-        $image->core()->setNative(
-            $image->core()->native()->colourspace(Interpretation::SRGB),
-        );
+        try {
+            $grayscale = $image->core()->native()->colourspace(Interpretation::B_W);
+
+            try {
+                $native = $grayscale->colourspace($interpretation);
+            } catch (VipsException) {
+                // colourspace() takes its target verbatim. Interpretations
+                // like multiband, matrix or rgb are tags rather than color
+                // spaces and it has no route back to them, so those images
+                // stay in srgb the way they did before.
+                $native = $grayscale->colourspace(Interpretation::SRGB);
+            }
+        } catch (VipsException $e) {
+            throw new ModifierException('Failed to modify image to grayscale', previous: $e);
+        }
+
+        // the whole conversion is committed at once, a failed restore must not
+        // leave the caller holding the b-w intermediate
+        $image->core()->setNative($native);
 
         return $image;
     }

--- a/tests/Unit/Modifiers/GrayscaleModifierTest.php
+++ b/tests/Unit/Modifiers/GrayscaleModifierTest.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Tests\Unit\Modifiers;
 
+use Intervention\Image\Colors\Cmyk\Channels\Key;
+use Intervention\Image\Colors\Cmyk\Colorspace as CmykColorspace;
+use Intervention\Image\Drivers\Vips\Decoders\NativeObjectDecoder;
+use Intervention\Image\Drivers\Vips\Driver;
 use Intervention\Image\Drivers\Vips\Modifiers\GrayscaleModifier;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
+use Jcupitt\Vips\BandFormat;
+use Jcupitt\Vips\Image as VipsImage;
+use Jcupitt\Vips\Interpretation;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(GrayscaleModifier::class)]
@@ -17,5 +24,59 @@ final class GrayscaleModifierTest extends BaseTestCase
         $this->assertFalse($image->colorAt(0, 0)->isGrayscale());
         $image->modify(new GrayscaleModifier());
         $this->assertTrue($image->colorAt(0, 0)->isGrayscale());
+    }
+
+    public function testColorspaceIsPreserved(): void
+    {
+        $image = $this->readTestImage('cmyk.jpg');
+        $this->assertEquals(Interpretation::CMYK, $image->core()->native()->interpretation);
+        $this->assertEquals(CmykColorspace::class, $image->colorspace()::class);
+
+        $image->modify(new GrayscaleModifier());
+
+        // grayscale is a color operation, it has no business moving a cmyk
+        // source to another colorspace
+        $this->assertEquals(Interpretation::CMYK, $image->core()->native()->interpretation);
+        $this->assertEquals(CmykColorspace::class, $image->colorspace()::class);
+        $this->assertEquals(4, $image->core()->native()->bands);
+
+        // the grey has to sit in the black channel, the three ink channels
+        // carry no color anymore. The exact key value goes through libvips'
+        // bundled cmyk profile and the lcms2 it was built against, so it is
+        // asserted as a range rather than pinned.
+        $color = $image->colorAt(0, 0);
+        $this->assertTrue($color->isGrayscale());
+        $this->assertGreaterThanOrEqual(35, $color->channel(Key::class)->value());
+        $this->assertLessThanOrEqual(45, $color->channel(Key::class)->value());
+    }
+
+    public function testInterpretationsWithoutARouteBackFallBackToSrgb(): void
+    {
+        // multiband is a tag rather than a colorspace, colourspace() can guess
+        // it as srgb on the way in but has no route back to it
+        $native = VipsImage::black(4, 4, ['bands' => 3])->add([200, 30, 90])->cast(BandFormat::UCHAR);
+        $this->assertEquals(Interpretation::MULTIBAND, $native->interpretation);
+
+        $image = (new Driver())->decodeImage($native, [NativeObjectDecoder::class]);
+        $image->modify(new GrayscaleModifier());
+
+        $this->assertEquals(Interpretation::SRGB, $image->core()->native()->interpretation);
+        $this->assertTrue($image->colorAt(0, 0)->isGrayscale());
+    }
+
+    public function testColorspaceIsPreservedForSrgb(): void
+    {
+        // pinning test, the srgb path already behaved this way, it guards the
+        // common case against the change made for cmyk
+        $image = $this->readTestImage('trim.png');
+        $bands = $image->core()->native()->bands;
+        $this->assertEquals(4, $bands);
+
+        $image->modify(new GrayscaleModifier());
+
+        // the srgb path is the common one and has to come out unchanged,
+        // bandcount included
+        $this->assertEquals(Interpretation::SRGB, $image->core()->native()->interpretation);
+        $this->assertEquals($bands, $image->core()->native()->bands);
     }
 }


### PR DESCRIPTION
`GrayscaleModifier` converts to `B_W` and then hardcodes `SRGB` on the way back, so a cmyk source comes out srgb. Same thing the Imagick driver did in Intervention/image#1516, where olivervogel said `grayscale()` is just a visual color operation and that the vips driver behaving this way "is actually more of a bug than a feature". This is that change for vips.

On `tests/resources/cmyk.jpg`, pixel (0,0):

```
source                     cmyk(5 58 7 0)
before                     rgb(163 163 163)   interpretation srgb
now                        cmyk(0 0 0 40)     interpretation cmyk
```

The grey lands in the black channel and the ink channels come out at zero. The srgb path is untouched, the second call was already going back to srgb there. Bandcount is unchanged in every direction, 3 stays 3, 4 stays 4, cmyk stays 4, and alpha survives the `B_W` round trip. I had `CanNormalizeBands` in here at first and took it out, it never fires on this path and it would have turned a 3 band srgb source into 4.

One thing that is not obvious. `colourspace()` guesses a sensible source interpretation on the way in, but it takes its target verbatim. So restoring the raw interpretation throws for the ones that are tags rather than color spaces, and those are reachable:

```php
$manager->decode(Vips\Image::black(10, 10, ['bands' => 3]));   // multiband
$manager->decode(Vips\Image::newFromArray([[1,2],[3,4]]));     // matrix
```

`multiband`, `matrix` and `rgb` all threw a raw `Jcupitt\Vips\Exception` with the plain restore. They fall back to srgb now, the way they behaved before. `yxy`, `labq` and `scrgb` round-trip fine and are preserved.

The two conversions are also built as one pipeline and committed with a single `setNative()`. With two calls the `B_W` intermediate was already committed when the restore threw, so the caller was left holding a 1 band image with its color gone.

Worth knowing, on the encoder side. A cmyk source now stays cmyk through to the encoder, and libvips attaches its built-in cmyk profile:

```
cmyk.jpg plain encode         2750558 bytes   (the fixture carries a 2.7 MB profile)
after grayscale, before       1803 bytes
after grayscale, now          963682 bytes    strip: true gives 962199
```

So `grayscale()` used to double as "drop the cmyk profile", because it laundered the image to srgb. It no longer does. The output is a valid cmyk JPEG, though most browsers will not render one. `strip: true` does not remove the profile either, `JpegEncoder` maps strip to `ForeignKeep::ICC`, which keeps ICC. Tell me if you would rather handle that at the encoder level.

Also worth knowing: `grayscale()` is no longer idempotent on cmyk. Repeated calls drift the black channel, raw K goes 101, 113, 126, 138, 149, and by the fifth pass a little color comes back. Each pass is another round trip through the cmyk profile. It converged before because it landed on srgb and stayed there.

Three tests, one on the cmyk colorspace and the resulting ink values, one on the tag fallback, one pinning the srgb path and its bandcount. The first fails on `develop`. The key assertion is a range rather than a fixed value, the exact number depends on the lcms2 the build linked against and I only have one locally. Full suite, phpstan and phpcs pass, the only failure is `FontProcessorTest::testBoxSizeTtf` which fails on `develop` too.
