### PR TITLE
fix(modifiers): strip meta data at save time

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -53,6 +53,7 @@ class Core implements CoreInterface, Iterator
 
     protected int $iteratorIndex = 0;
     protected int $chainedOperations = 0;
+    protected bool $metaStripped = false;
     protected CollectionInterface $meta;
     protected null|PathSource|BufferSource $stashedSource = null;
 
@@ -216,6 +217,36 @@ class Core implements CoreInterface, Iterator
     public function setStashedSource(PathSource|BufferSource $source): self
     {
         $this->stashedSource = $source;
+
+        return $this;
+    }
+
+    /**
+     * Whether the meta data of this core has been stripped.
+     *
+     * libvips builds an EXIF block from the image's core fields at save time,
+     * whether or not the image carries one, so removing the fields from the
+     * image cannot keep meta data out of the encoded result on its own. The
+     * encoders read this flag to pass the matching keep option to the save.
+     */
+    public function metaStripped(): bool
+    {
+        return $this->metaStripped;
+    }
+
+    /**
+     * Mark the meta data of this core as stripped. Set by StripMetaModifier
+     * and, unlike the stashed source, kept across setNative() so the flag
+     * survives any modifier that runs between the strip and the encoding.
+     *
+     * It does not survive a new core built around the same vips image, as
+     * Frame::toImage() and createFromFrames() do. Such an image carries no
+     * meta data, its fields were removed, but libvips synthesises an EXIF
+     * block for it again at save time.
+     */
+    public function setMetaStripped(bool $stripped = true): self
+    {
+        $this->metaStripped = $stripped;
 
         return $this;
     }

--- a/src/Encoders/AvifEncoder.php
+++ b/src/Encoders/AvifEncoder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Encoders;
 
+use Intervention\Image\Drivers\Vips\Traits\CanStripMeta;
 use Intervention\Image\EncodedImage;
 use Intervention\Image\Encoders\AvifEncoder as GenericAvifEncoder;
 use Intervention\Image\Exceptions\EncoderException;
@@ -13,12 +14,12 @@ use Intervention\Image\Exceptions\StateException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
 use Intervention\Image\MediaType;
-use Jcupitt\Vips\Config as VipsConfig;
 use Jcupitt\Vips\Exception as VipsException;
-use Jcupitt\Vips\ForeignKeep;
 
 class AvifEncoder extends GenericAvifEncoder implements SpecializedInterface
 {
+    use CanStripMeta;
+
     /**
      * {@inheritdoc}
      *
@@ -32,7 +33,7 @@ class AvifEncoder extends GenericAvifEncoder implements SpecializedInterface
     public function encode(ImageInterface $image): EncodedImage
     {
         try {
-            $result = $image->core()->native()->writeToBuffer('.avif', $this->options());
+            $result = $image->core()->native()->writeToBuffer('.avif', $this->options($image));
         } catch (VipsException $e) {
             throw new EncoderException('Failed to encode AVIF image format ', previous: $e);
         }
@@ -44,27 +45,14 @@ class AvifEncoder extends GenericAvifEncoder implements SpecializedInterface
      * @throws StateException
      * @return array{lossless: bool, Q: int, effort: int, keep?: int, strip?: bool}
      */
-    private function options(): array
+    private function options(ImageInterface $image): array
     {
-        $options = [
+        return array_merge([
             'lossless' => $this->quality === 100,
             'Q' => $this->quality,
             // libvips' heifsave defaults to effort=4; 1 encodes ~2-3x faster
             // with near-identical bytes on typical web sources (range 0..9).
             'effort' => 1,
-        ];
-
-        $strip = $this->strip || $this->driver()->config()->strip;
-
-        if (VipsConfig::atLeast(8, 15)) {
-            $keepAll = VipsConfig::atLeast(8, 18)
-                ? ForeignKeep::ALL
-                : ForeignKeep::ALL & ~ForeignKeep::GAINMAP;
-            $options['keep'] = $strip ? ForeignKeep::ICC : $keepAll;
-        } else {
-            $options['strip'] = $strip;
-        }
-
-        return $options;
+        ], $this->metaOptions($image, $this->strip));
     }
 }

--- a/src/Encoders/GifEncoder.php
+++ b/src/Encoders/GifEncoder.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Encoders;
 
+use Intervention\Image\Drivers\Vips\Traits\CanStripMeta;
 use Intervention\Image\EncodedImage;
 use Intervention\Image\Encoders\GifEncoder as GenericGifEncoder;
 use Intervention\Image\Exceptions\EncoderException;
 use Intervention\Image\Exceptions\StreamException;
 use Intervention\Image\Exceptions\InvalidArgumentException;
+use Intervention\Image\Exceptions\StateException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
 use Intervention\Image\MediaType;
@@ -16,6 +18,8 @@ use Jcupitt\Vips\Exception as VipsException;
 
 class GifEncoder extends GenericGifEncoder implements SpecializedInterface
 {
+    use CanStripMeta;
+
     /**
      * {@inheritdoc}
      *
@@ -24,13 +28,14 @@ class GifEncoder extends GenericGifEncoder implements SpecializedInterface
      * @throws InvalidArgumentException
      * @throws EncoderException
      * @throws StreamException
+     * @throws StateException
      */
     public function encode(ImageInterface $image): EncodedImage
     {
         try {
-            $result = $image->core()->native()->writeToBuffer('.gif', [
+            $result = $image->core()->native()->writeToBuffer('.gif', array_merge([
                 'interlace' => $this->interlaced,
-            ]);
+            ], $this->metaOptions($image)));
         } catch (VipsException $e) {
             throw new EncoderException('Failed to encode GIF image format', previous: $e);
         }

--- a/src/Encoders/HeicEncoder.php
+++ b/src/Encoders/HeicEncoder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Encoders;
 
+use Intervention\Image\Drivers\Vips\Traits\CanStripMeta;
 use Intervention\Image\EncodedImage;
 use Intervention\Image\Encoders\HeicEncoder as GenericHeicEncoder;
 use Intervention\Image\Exceptions\EncoderException;
@@ -13,12 +14,12 @@ use Intervention\Image\Exceptions\StateException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
 use Intervention\Image\MediaType;
-use Jcupitt\Vips\Config as VipsConfig;
 use Jcupitt\Vips\Exception as VipsException;
-use Jcupitt\Vips\ForeignKeep;
 
 class HeicEncoder extends GenericHeicEncoder implements SpecializedInterface
 {
+    use CanStripMeta;
+
     /**
      * {@inheritdoc}
      *
@@ -32,7 +33,7 @@ class HeicEncoder extends GenericHeicEncoder implements SpecializedInterface
     public function encode(ImageInterface $image): EncodedImage
     {
         try {
-            $result = $image->core()->native()->writeToBuffer('.heic', $this->options());
+            $result = $image->core()->native()->writeToBuffer('.heic', $this->options($image));
         } catch (VipsException $e) {
             throw new EncoderException('Failed to encode HEIC image format', previous: $e);
         }
@@ -44,27 +45,14 @@ class HeicEncoder extends GenericHeicEncoder implements SpecializedInterface
      * @throws StateException
      * @return array{lossless: bool, Q: int, effort: int, keep?: int, strip?: bool}
      */
-    private function options(): array
+    private function options(ImageInterface $image): array
     {
-        $options = [
+        return array_merge([
             'lossless' => $this->quality === 100,
             'Q' => $this->quality,
             // libvips' heifsave defaults to effort=4; 1 encodes ~2-3x faster
             // with near-identical bytes on typical web sources (range 0..9).
             'effort' => 1,
-        ];
-
-        $strip = $this->strip || $this->driver()->config()->strip;
-
-        if (VipsConfig::atLeast(8, 15)) {
-            $keepAll = VipsConfig::atLeast(8, 18)
-                ? ForeignKeep::ALL
-                : ForeignKeep::ALL & ~ForeignKeep::GAINMAP;
-            $options['keep'] = $strip ? ForeignKeep::ICC : $keepAll;
-        } else {
-            $options['strip'] = $strip;
-        }
-
-        return $options;
+        ], $this->metaOptions($image, $this->strip));
     }
 }

--- a/src/Encoders/Jpeg2000Encoder.php
+++ b/src/Encoders/Jpeg2000Encoder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Encoders;
 
+use Intervention\Image\Drivers\Vips\Traits\CanStripMeta;
 use Intervention\Image\EncodedImage;
 use Intervention\Image\Encoders\Jpeg2000Encoder as GenericJpeg2000Encoder;
 use Intervention\Image\Exceptions\EncoderException;
@@ -13,12 +14,12 @@ use Intervention\Image\Exceptions\StateException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
 use Intervention\Image\MediaType;
-use Jcupitt\Vips\Config as VipsConfig;
 use Jcupitt\Vips\Exception as VipsException;
-use Jcupitt\Vips\ForeignKeep;
 
 class Jpeg2000Encoder extends GenericJpeg2000Encoder implements SpecializedInterface
 {
+    use CanStripMeta;
+
     /**
      * {@inheritdoc}
      *
@@ -38,7 +39,7 @@ class Jpeg2000Encoder extends GenericJpeg2000Encoder implements SpecializedInter
         }
 
         try {
-            $result = $vipsImage->writeToBuffer('.j2k', $this->options());
+            $result = $vipsImage->writeToBuffer('.j2k', $this->options($image));
         } catch (VipsException $e) {
             throw new EncoderException('Failed to encode Jpeg2000 image format', previous: $e);
         }
@@ -50,24 +51,11 @@ class Jpeg2000Encoder extends GenericJpeg2000Encoder implements SpecializedInter
      * @throws StateException
     * @return array{lossless: bool, Q: int, keep?: int, strip?: bool}
     */
-    private function options(): array
+    private function options(ImageInterface $image): array
     {
-        $options = [
+        return array_merge([
             'lossless' => $this->quality === 100,
             'Q' => $this->quality,
-        ];
-
-        $strip = $this->strip || $this->driver()->config()->strip;
-
-        if (VipsConfig::atLeast(8, 15)) {
-            $keepAll = VipsConfig::atLeast(8, 18)
-                ? ForeignKeep::ALL
-                : ForeignKeep::ALL & ~ForeignKeep::GAINMAP;
-            $options['keep'] = $strip ? ForeignKeep::ICC : $keepAll;
-        } else {
-            $options['strip'] = $strip;
-        }
-
-        return $options;
+        ], $this->metaOptions($image, $this->strip));
     }
 }

--- a/src/Encoders/JpegEncoder.php
+++ b/src/Encoders/JpegEncoder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers\Vips\Encoders;
 
 use Intervention\Image\Colors\Cmyk\Colorspace as CmykColorspace;
+use Intervention\Image\Drivers\Vips\Traits\CanStripMeta;
 use Intervention\Image\EncodedImage;
 use Intervention\Image\Encoders\JpegEncoder as GenericJpegEncoder;
 use Intervention\Image\Exceptions\EncoderException;
@@ -14,12 +15,12 @@ use Intervention\Image\Exceptions\StateException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
 use Intervention\Image\MediaType;
-use Jcupitt\Vips\Config as VipsConfig;
 use Jcupitt\Vips\Exception as VipsException;
-use Jcupitt\Vips\ForeignKeep;
 
 class JpegEncoder extends GenericJpegEncoder implements SpecializedInterface
 {
+    use CanStripMeta;
+
     /**
      * {@inheritdoc}
      *
@@ -54,7 +55,7 @@ class JpegEncoder extends GenericJpegEncoder implements SpecializedInterface
      *     interlace: bool,
      *     optimize_coding: true,
      *     background?: array<float>,
-     *     keep?: 8|63,
+     *     keep?: int,
      *     strip?: bool
      * }
      */
@@ -70,18 +71,7 @@ class JpegEncoder extends GenericJpegEncoder implements SpecializedInterface
             $options['background'] = $this->backgroundColor($image);
         }
 
-        $strip = $this->strip || $this->driver()->config()->strip;
-
-        if (VipsConfig::atLeast(8, 15)) {
-            $keepAll = VipsConfig::atLeast(8, 18)
-                ? ForeignKeep::ALL
-                : ForeignKeep::ALL & ~ForeignKeep::GAINMAP;
-            $options['keep'] = $strip ? ForeignKeep::ICC : $keepAll;
-        } else {
-            $options['strip'] = $strip;
-        }
-
-        return $options;
+        return array_merge($options, $this->metaOptions($image, $this->strip));
     }
 
     /**

--- a/src/Encoders/JxlEncoder.php
+++ b/src/Encoders/JxlEncoder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Encoders;
 
+use Intervention\Image\Drivers\Vips\Traits\CanStripMeta;
 use Intervention\Image\EncodedImage;
 use Intervention\Image\Encoders\JxlEncoder as GenericJxlEncoder;
 use Intervention\Image\Exceptions\EncoderException;
@@ -13,12 +14,12 @@ use Intervention\Image\Exceptions\StateException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
 use Intervention\Image\MediaType;
-use Jcupitt\Vips\Config as VipsConfig;
 use Jcupitt\Vips\Exception as VipsException;
-use Jcupitt\Vips\ForeignKeep;
 
 class JxlEncoder extends GenericJxlEncoder implements SpecializedInterface
 {
+    use CanStripMeta;
+
     /**
      * {@inheritdoc}
      *
@@ -32,7 +33,7 @@ class JxlEncoder extends GenericJxlEncoder implements SpecializedInterface
     public function encode(ImageInterface $image): EncodedImage
     {
         try {
-            $result = $image->core()->native()->writeToBuffer('.jxl', $this->options());
+            $result = $image->core()->native()->writeToBuffer('.jxl', $this->options($image));
         } catch (VipsException $e) {
             throw new EncoderException('Failed to encode JXL image format', previous: $e);
         }
@@ -48,24 +49,11 @@ class JxlEncoder extends GenericJxlEncoder implements SpecializedInterface
      * @throws StateException
      * @return array{lossless: bool, Q: int, keep?: int, strip?: bool}
      */
-    private function options(): array
+    private function options(ImageInterface $image): array
     {
-        $options = [
+        return array_merge([
             'lossless' => $this->quality === 100,
             'Q' => $this->quality,
-        ];
-
-        $strip = $this->strip || $this->driver()->config()->strip;
-
-        if (VipsConfig::atLeast(8, 15)) {
-            $keepAll = VipsConfig::atLeast(8, 18)
-                ? ForeignKeep::ALL
-                : ForeignKeep::ALL & ~ForeignKeep::GAINMAP;
-            $options['keep'] = $strip ? ForeignKeep::ICC : $keepAll;
-        } else {
-            $options['strip'] = $strip;
-        }
-
-        return $options;
+        ], $this->metaOptions($image, $this->strip));
     }
 }

--- a/src/Encoders/PngEncoder.php
+++ b/src/Encoders/PngEncoder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Encoders;
 
+use Intervention\Image\Drivers\Vips\Traits\CanStripMeta;
 use Intervention\Image\EncodedImage;
 use Intervention\Image\Encoders\PngEncoder as GenericPngEncoder;
 use Intervention\Image\Exceptions\EncoderException;
@@ -17,6 +18,8 @@ use Jcupitt\Vips\Exception as VipsException;
 
 class PngEncoder extends GenericPngEncoder implements SpecializedInterface
 {
+    use CanStripMeta;
+
     /**
      * {@inheritdoc}
      *
@@ -36,10 +39,10 @@ class PngEncoder extends GenericPngEncoder implements SpecializedInterface
         }
 
         try {
-            $result = $vipsImage->writeToBuffer('.png', [
+            $result = $vipsImage->writeToBuffer('.png', array_merge([
                 'interlace' => $this->interlaced,
                 'palette' => $this->indexed,
-            ]);
+            ], $this->metaOptions($image)));
         } catch (VipsException $e) {
             throw new EncoderException('Failed to encode PNG image format', previous: $e);
         }

--- a/src/Encoders/TiffEncoder.php
+++ b/src/Encoders/TiffEncoder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Encoders;
 
+use Intervention\Image\Drivers\Vips\Traits\CanStripMeta;
 use Intervention\Image\EncodedImage;
 use Intervention\Image\Encoders\TiffEncoder as GenericTiffEncoder;
 use Intervention\Image\Exceptions\EncoderException;
@@ -13,12 +14,12 @@ use Intervention\Image\Exceptions\StateException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
 use Intervention\Image\MediaType;
-use Jcupitt\Vips\Config as VipsConfig;
-use Jcupitt\Vips\ForeignKeep;
 use Jcupitt\Vips\Exception as VipsException;
 
 class TiffEncoder extends GenericTiffEncoder implements SpecializedInterface
 {
+    use CanStripMeta;
+
     /**
      * {@inheritdoc}
      *
@@ -32,7 +33,7 @@ class TiffEncoder extends GenericTiffEncoder implements SpecializedInterface
     public function encode(ImageInterface $image): EncodedImage
     {
         try {
-            $result = $image->core()->native()->writeToBuffer('.tiff', $this->options());
+            $result = $image->core()->native()->writeToBuffer('.tiff', $this->options($image));
         } catch (VipsException $e) {
             throw new EncoderException('Failed to encode TIFF image format', previous: $e);
         }
@@ -44,24 +45,11 @@ class TiffEncoder extends GenericTiffEncoder implements SpecializedInterface
      * @throws StateException
      * @return array{lossless: bool, Q: int, keep?: int, strip?: bool}
      */
-    private function options(): array
+    private function options(ImageInterface $image): array
     {
-        $options = [
+        return array_merge([
             'lossless' => $this->quality === 100,
             'Q' => $this->quality,
-        ];
-
-        $strip = $this->strip || $this->driver()->config()->strip;
-
-        if (VipsConfig::atLeast(8, 15)) {
-            $keepAll = VipsConfig::atLeast(8, 18)
-                ? ForeignKeep::ALL
-                : ForeignKeep::ALL & ~ForeignKeep::GAINMAP;
-            $options['keep'] = $strip ? ForeignKeep::ICC : $keepAll;
-        } else {
-            $options['strip'] = true;
-        }
-
-        return $options;
+        ], $this->metaOptions($image, $this->strip));
     }
 }

--- a/src/Encoders/WebpEncoder.php
+++ b/src/Encoders/WebpEncoder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Encoders;
 
+use Intervention\Image\Drivers\Vips\Traits\CanStripMeta;
 use Intervention\Image\EncodedImage;
 use Intervention\Image\Encoders\WebpEncoder as GenericWebpEncoder;
 use Intervention\Image\Exceptions\EncoderException;
@@ -13,12 +14,12 @@ use Intervention\Image\Exceptions\StateException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
 use Intervention\Image\MediaType;
-use Jcupitt\Vips\Config as VipsConfig;
-use Jcupitt\Vips\ForeignKeep;
 use Jcupitt\Vips\Exception as VipsException;
 
 class WebpEncoder extends GenericWebpEncoder implements SpecializedInterface
 {
+    use CanStripMeta;
+
     /**
      * {@inheritdoc}
      *
@@ -32,7 +33,7 @@ class WebpEncoder extends GenericWebpEncoder implements SpecializedInterface
     public function encode(ImageInterface $image): EncodedImage
     {
         try {
-            $result = $image->core()->native()->writeToBuffer('.webp', $this->options());
+            $result = $image->core()->native()->writeToBuffer('.webp', $this->options($image));
         } catch (VipsException $e) {
             throw new EncoderException('Failed to encode WEBP image format ', previous: $e);
         }
@@ -44,28 +45,15 @@ class WebpEncoder extends GenericWebpEncoder implements SpecializedInterface
      * @throws StateException
      * @return array{lossless: bool, Q: int, effort: int, keep?: int, strip?: bool}
      */
-    private function options(): array
+    private function options(ImageInterface $image): array
     {
-        $options = [
+        return array_merge([
             'lossless' => $this->quality === 100,
             'Q' => $this->quality,
             // libvips' webpsave defaults to effort=4; 2 roughly halves encode
             // time while staying within ~3% bytes (effort=1 costs +10-19%;
             // range 0..6).
             'effort' => 2,
-        ];
-
-        $strip = $this->strip || $this->driver()->config()->strip;
-
-        if (VipsConfig::atLeast(8, 15)) {
-            $keepAll = VipsConfig::atLeast(8, 18)
-                ? ForeignKeep::ALL
-                : ForeignKeep::ALL & ~ForeignKeep::GAINMAP;
-            $options['keep'] = $strip ? ForeignKeep::ICC : $keepAll;
-        } else {
-            $options['strip'] = $strip;
-        }
-
-        return $options;
+        ], $this->metaOptions($image, $this->strip));
     }
 }

--- a/src/Modifiers/StripMetaModifier.php
+++ b/src/Modifiers/StripMetaModifier.php
@@ -5,18 +5,40 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers\Vips\Modifiers;
 
 use Intervention\Image\Collection;
+use Intervention\Image\Drivers\Vips\Core;
 use Intervention\Image\Exceptions\DriverException;
+use Intervention\Image\Exceptions\InvalidArgumentException;
 use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\ModifierInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
-use Jcupitt\Vips\Config as VipsConfig;
 use Jcupitt\Vips\Exception as VipsException;
-use Jcupitt\Vips\ForeignKeep;
-use Jcupitt\Vips\Image as VipsImage;
 
 class StripMetaModifier implements ModifierInterface, SpecializedInterface
 {
+    /**
+     * Meta data fields libvips attaches to an image when it decodes one. The
+     * color profile is deliberately not among them, stripping meta data keeps
+     * it, in line with what the encoders of this driver do for their strip
+     * parameter.
+     */
+    private const META_FIELDS = [
+        'image-description',
+        'iptc-data',
+        'jpeg-thumbnail-data',
+        'photoshop-data',
+        'xmp-data',
+    ];
+
+    /**
+     * Prefixes of meta data fields that libvips numbers or names after the tag
+     * they hold, "exif-ifd0-Artist" or "png-comment-0-Software" for instance.
+     */
+    private const META_FIELD_PREFIXES = [
+        'exif-',
+        'png-comment-',
+    ];
+
     /**
      * {@inheritdoc}
      *
@@ -24,26 +46,58 @@ class StripMetaModifier implements ModifierInterface, SpecializedInterface
      *
      * @throws ModifierException
      * @throws DriverException
+     * @throws InvalidArgumentException
      */
     public function apply(ImageInterface $image): ImageInterface
     {
-        $options = VipsConfig::atLeast(8, 15) ? [
-            'keep' => ForeignKeep::ICC,
-        ] : [
-            'strip' => true,
-        ];
+        $core = $image->core();
+
+        if (!$core instanceof Core) {
+            throw new ModifierException('Failed to strip meta data, image is not backed by ' . Core::class);
+        }
 
         try {
-            $buf = $image->core()->native()->tiffsave_buffer($options);
-            $image->setExif(new Collection());
-            $image->core()->setNative(
-                VipsImage::newFromBuffer($buf),
-            );
+            // work on a copy so the fields of an image shared with a clone stay put
+            $native = $core->native()->copy();
+
+            foreach ($native->getFields() as $field) {
+                if ($this->isMetaField($field)) {
+                    $native->remove($field);
+                }
+            }
         } catch (VipsException $e) {
             throw new ModifierException('Failed to strip meta data from image', previous: $e);
         }
 
+        // removing the fields is not enough, libvips builds an EXIF block from
+        // the image's core fields at save time. Mark the core so the encoders
+        // tell the save to keep it out of the result as well. Both run before
+        // setNative(), which can throw once it renders the pipeline to memory.
+        $image->setExif(new Collection());
+        $core->setMetaStripped();
+
+        // this also clears the stashed source on purpose. Keeping it would let
+        // a later resize reload the original file and put the fields back.
+        $core->setNative($native);
 
         return $image;
+    }
+
+    /**
+     * Determine whether the given vips field holds meta data.
+     */
+    private function isMetaField(string $field): bool
+    {
+        if (in_array($field, self::META_FIELDS, true)) {
+            return true;
+        }
+
+        foreach (self::META_FIELD_PREFIXES as $prefix) {
+            if (str_starts_with($field, $prefix)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Traits/CanStripMeta.php
+++ b/src/Traits/CanStripMeta.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Intervention\Image\Drivers\Vips\Traits;
+
+use Intervention\Image\Drivers\Vips\Core;
+use Intervention\Image\Exceptions\StateException;
+use Intervention\Image\Interfaces\DriverInterface;
+use Intervention\Image\Interfaces\ImageInterface;
+use Jcupitt\Vips\Config as VipsConfig;
+use Jcupitt\Vips\ForeignKeep;
+
+trait CanStripMeta
+{
+    /**
+     * Encoders using this trait are driver specialized, the driver carries the
+     * global strip config. Declared so a class that is not gets caught at load
+     * time rather than on the first encode.
+     */
+    abstract public function driver(): DriverInterface;
+
+    /**
+     * Return the meta data options of libvips' save operation for the given image.
+     *
+     * libvips builds an EXIF block from the image's core fields at save time,
+     * whether or not the image carries one, so the save operation is the only
+     * place where meta data can be kept out of the encoded result. Removing
+     * the fields from the image beforehand does not reach it, which is why an
+     * image stripped by StripMetaModifier is reported by its core here.
+     *
+     * @throws StateException
+     * @return array{keep: int}|array{strip: bool}
+     */
+    private function metaOptions(ImageInterface $image, ?bool $strip = null): array
+    {
+        $core = $image->core();
+
+        $strip = ($strip ?? false)
+            || $this->driver()->config()->strip
+            || ($core instanceof Core && $core->metaStripped());
+
+        if (!VipsConfig::atLeast(8, 15)) {
+            return ['strip' => $strip];
+        }
+
+        // GAINMAP only exists from libvips 8.18, passing it to 8.15-8.17 spams
+        // stderr with a GLib-GObject-CRITICAL on every encode
+        $keepAll = VipsConfig::atLeast(8, 18)
+            ? ForeignKeep::ALL
+            : ForeignKeep::ALL & ~ForeignKeep::GAINMAP;
+
+        return ['keep' => $strip ? ForeignKeep::ICC : $keepAll];
+    }
+}

--- a/tests/Unit/CoreTest.php
+++ b/tests/Unit/CoreTest.php
@@ -182,6 +182,43 @@ class CoreTest extends BaseTestCase
         $this->assertNull($core->stashedSource());
     }
 
+    public function testMetaStrippedIsFalseByDefault(): void
+    {
+        $core = new Core($this->vipsImage(10, 10, [255, 0, 0]));
+
+        $this->assertFalse($core->metaStripped());
+    }
+
+    public function testSetMetaStrippedThenGet(): void
+    {
+        $core = new Core($this->vipsImage(10, 10, [255, 0, 0]));
+
+        $this->assertTrue($core->setMetaStripped()->metaStripped());
+        $this->assertFalse($core->setMetaStripped(false)->metaStripped());
+    }
+
+    /**
+     * Unlike the stashed source, the flag has to survive setNative() so it
+     * still reaches the encoder after any modifier that runs after the strip.
+     */
+    public function testSetNativeKeepsMetaStripped(): void
+    {
+        $core = new Core($this->vipsImage(10, 10, [255, 0, 0]));
+        $core->setMetaStripped();
+
+        $core->setNative($this->vipsImage(20, 20, [0, 255, 0]));
+
+        $this->assertTrue($core->metaStripped());
+    }
+
+    public function testCloneKeepsMetaStripped(): void
+    {
+        $core = new Core($this->vipsImage(10, 10, [255, 0, 0]));
+        $core->setMetaStripped();
+
+        $this->assertTrue((clone $core)->metaStripped());
+    }
+
     public function testSetNativeLeavesThePipelineLazyBelowTheOperationLimit(): void
     {
         $core = new Core($this->vipsImage(10, 10, [255, 0, 0]));

--- a/tests/Unit/Encoders/PngEncoderTest.php
+++ b/tests/Unit/Encoders/PngEncoderTest.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Intervention\Image\Drivers\Vips\Tests\Unit\Encoders;
 
 use Generator;
+use Intervention\Image\Config;
 use Intervention\Image\Drivers\Vips\Driver;
 use Intervention\Image\Drivers\Vips\Encoders\PngEncoder;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
 use Intervention\Image\Drivers\Vips\Tests\Traits\CanInspectPngFormat;
+use Intervention\Image\EncodedImage;
 use Intervention\Image\Interfaces\ImageInterface;
+use Jcupitt\Vips\Image as VipsImage;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -22,6 +25,7 @@ final class PngEncoderTest extends BaseTestCase
     {
         $image = (new Driver())->createImage(3, 2);
         $encoder = new PngEncoder();
+        $encoder->setDriver(new Driver());
         $result = $encoder->encode($image);
         $this->assertMediaType('image/png', $result);
         $this->assertEquals('image/png', $result->mimetype());
@@ -32,10 +36,29 @@ final class PngEncoderTest extends BaseTestCase
     {
         $image = (new Driver())->createImage(3, 2);
         $encoder = new PngEncoder(interlaced: true);
+        $encoder->setDriver(new Driver());
         $result = $encoder->encode($image);
         $this->assertMediaType('image/png', $result);
         $this->assertEquals('image/png', $result->mimetype());
         $this->assertTrue($this->isInterlacedPng($result));
+    }
+
+    public function testEncodeKeepsMetaDataByDefault(): void
+    {
+        $image = $this->readTestImage('exif.jpg');
+        $encoder = new PngEncoder();
+        $encoder->setDriver(new Driver());
+
+        $this->assertContains('exif-data', $this->encodedFields($encoder->encode($image)));
+    }
+
+    public function testEncodeStripsMetaDataWhenConfigured(): void
+    {
+        $image = $this->readTestImage('exif.jpg');
+        $encoder = new PngEncoder();
+        $encoder->setDriver(new Driver(new Config(strip: true)));
+
+        $this->assertNotContains('exif-data', $this->encodedFields($encoder->encode($image)));
     }
 
     public function testEncodeAnimated(): void
@@ -50,10 +73,22 @@ final class PngEncoderTest extends BaseTestCase
     #[DataProvider('indexedDataProvider')]
     public function testEncoderIndexed(ImageInterface $image, PngEncoder $encoder, string $result): void
     {
+        $encoder->setDriver(new Driver());
+
         $this->assertEquals(
             $result,
             $this->pngColorType($encoder->encode($image)),
         );
+    }
+
+    /**
+     * Read back the header field names of the given encoded result.
+     *
+     * @return list<string>
+     */
+    private function encodedFields(EncodedImage $encoded): array
+    {
+        return VipsImage::newFromBuffer((string) $encoded)->getFields();
     }
 
     public static function indexedDataProvider(): Generator

--- a/tests/Unit/Modifiers/StripMetaModifierTest.php
+++ b/tests/Unit/Modifiers/StripMetaModifierTest.php
@@ -4,11 +4,18 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Tests\Unit\Modifiers;
 
+use Generator;
+use Intervention\Image\Drivers\Vips\Core;
 use Intervention\Image\Drivers\Vips\Modifiers\StripMetaModifier;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
 use Intervention\Image\Format;
+use Intervention\Image\Interfaces\ImageInterface;
+use Jcupitt\Vips\Image as VipsImage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-class StripMetaModifierTest extends BaseTestCase
+#[CoversClass(StripMetaModifier::class)]
+final class StripMetaModifierTest extends BaseTestCase
 {
     public function testStrip(): void
     {
@@ -18,5 +25,159 @@ class StripMetaModifierTest extends BaseTestCase
         $this->assertNull($image->exif('IFD0.Artist'));
         $result = $image->encodeUsingFormat(format: Format::JPEG);
         $this->assertEmpty(exif_read_data($result->toStream())['IFD0.Artist'] ?? null);
+    }
+
+    public function testStripRemovesMetaDataFromImage(): void
+    {
+        $stripped = [
+            'exif-data',
+            'exif-ifd0-Artist',
+            'iptc-data',
+            'jpeg-thumbnail-data',
+            'xmp-data',
+        ];
+
+        $image = $this->readTestImage('exif.jpg');
+        $fields = $image->core()->native()->getFields();
+
+        foreach ($stripped as $field) {
+            $this->assertContains($field, $fields);
+        }
+
+        $image->modify(new StripMetaModifier());
+        $fields = $image->core()->native()->getFields();
+
+        foreach ($stripped as $field) {
+            $this->assertNotContains($field, $fields);
+        }
+    }
+
+    public function testStripKeepsStructuralFields(): void
+    {
+        $image = $this->readTestImage('exif.jpg');
+        $image->modify(new StripMetaModifier());
+        $fields = $image->core()->native()->getFields();
+
+        foreach (['xres', 'yres', 'interpretation', 'resolution-unit', 'orientation'] as $field) {
+            $this->assertContains($field, $fields);
+        }
+    }
+
+    public function testStripRemovesTextChunks(): void
+    {
+        $image = $this->readTestImage('tile.png');
+        $this->assertContains('png-comment-0-Software', $image->core()->native()->getFields());
+        $image->modify(new StripMetaModifier());
+        $this->assertNotContains('png-comment-0-Software', $image->core()->native()->getFields());
+    }
+
+    /**
+     * libvips writes an EXIF block that it builds from the image's core fields
+     * at save time, whether or not the image carries one. Only the save
+     * operation itself can keep it out of the result.
+     */
+    #[DataProvider('formatProvider')]
+    public function testStripLeavesNoMetaDataInEncodedResult(Format $format): void
+    {
+        $image = $this->readTestImage('exif.jpg');
+        $image->modify(new StripMetaModifier());
+
+        $this->assertNotContains(
+            'exif-data',
+            $this->encodedHeaderFields($image, $format),
+            'Failed asserting that the encoded ' . $format->name . ' carries no EXIF block.',
+        );
+    }
+
+    public static function formatProvider(): Generator
+    {
+        yield 'jpeg' => [Format::JPEG];
+        yield 'png' => [Format::PNG];
+        yield 'webp' => [Format::WEBP];
+        yield 'avif' => [Format::AVIF];
+        yield 'tiff' => [Format::TIFF];
+    }
+
+    /**
+     * The strip must not leave the decoder's source ref stashed on the core.
+     * A resize served from that ref reloads the original file, which would put
+     * the removed fields straight back on the image.
+     */
+    public function testStripClearsStashedSourceSoLaterModifiersStayStripped(): void
+    {
+        $image = $this->readTestImage('exif.jpg');
+        $core = $image->core();
+        $this->assertInstanceOf(Core::class, $core);
+        $this->assertNotNull($core->stashedSource());
+
+        $image->modify(new StripMetaModifier());
+        $this->assertNull($core->stashedSource());
+
+        $image->resize(10, 10);
+        $this->assertNotContains('exif-data', $core->native()->getFields());
+        $this->assertNotContains('exif-data', $this->encodedHeaderFields($image, Format::JPEG));
+    }
+
+    /**
+     * A clone shares its vips image with the original, so the strip has to work
+     * on a copy. Removing the fields in place would empty both.
+     */
+    public function testStripOnCloneLeavesTheOriginalUntouched(): void
+    {
+        $image = $this->readTestImage('exif.jpg');
+        $clone = clone $image;
+        $clone->modify(new StripMetaModifier());
+
+        $this->assertNotContains('exif-data', $clone->core()->native()->getFields());
+        $this->assertContains('exif-data', $image->core()->native()->getFields());
+        $this->assertEquals('Oliver Vogel', $image->exif('IFD0.Artist'));
+        $this->assertContains('exif-data', $this->encodedHeaderFields($image, Format::JPEG));
+    }
+
+    public function testStripKeepsProfile(): void
+    {
+        $image = $this->readTestImage('icc.jpg');
+        $this->assertContains('icc-profile-data', $image->core()->native()->getFields());
+        $image->modify(new StripMetaModifier());
+
+        $fields = $this->encodedHeaderFields($image, Format::JPEG);
+        $this->assertContains('icc-profile-data', $fields);
+        $this->assertNotContains('exif-data', $fields);
+    }
+
+    public function testStripKeepsAnimation(): void
+    {
+        $image = $this->readTestImage('animation.gif');
+        $this->assertEquals(8, $image->count());
+        $image->modify(new StripMetaModifier());
+
+        $this->assertTrue($image->isAnimated());
+        // count() reads n-pages, which stayed at 8 even when the image held a
+        // single frame, so the frames themselves have to be reached as well
+        $this->assertEquals(8, $image->count());
+        $this->assertEquals(8, iterator_count($image->core()));
+        $this->assertEquals(15, $image->core()->frame(7)->native()->height);
+
+        $result = VipsImage::newFromBuffer(
+            (string) $image->encodeUsingFormat(format: Format::GIF),
+            'n=-1',
+        );
+        $this->assertEquals(8, $result->get('n-pages'));
+        $this->assertEquals(15, $result->get('page-height'));
+        $this->assertEquals([200, 200, 200, 200, 200, 200, 200, 200], $result->get('delay'));
+        $this->assertEquals(3, $result->get('loop'));
+    }
+
+    /**
+     * Read back the header field names of the given image encoded in the given
+     * format. Meta data lives in the header, so the first page is enough.
+     *
+     * @return list<string>
+     */
+    private function encodedHeaderFields(ImageInterface $image, Format $format): array
+    {
+        return VipsImage::newFromBuffer(
+            (string) $image->encodeUsingFormat(format: $format),
+        )->getFields();
     }
 }


### PR DESCRIPTION
`StripMetaModifier` strips by saving the image to a TIFF buffer with `keep => ForeignKeep::ICC` and reading it back. That removes the fields from the image, but the next save writes a 186 byte EXIF block anyway.

A brand new image carrying no metadata shows the same block, so it is not coming from the source:

```
VipsImage::black(10, 10) -> .jpg   exif-data 186 bytes
VipsImage::black(10, 10) -> .png   exif-data 180 bytes
```

I think libvips rebuilds it from `xres`, `yres` and `interpretation` at save time, and only the `keep` flag on the writer suppresses it. Removing fields from the image cannot reach that.

The round trip has two other effects. It reads back only the first TIFF page while `n-pages` stays at 8, so an animation loses its frames and still claims to have them (`count()` returns 8, `frame(3)` throws). And it puts the whole uncompressed TIFF into a PHP string, 207 MB on a 4000x2667 JPEG, which dies at the default `memory_limit` of 128M.

The modifier no longer round trips. It copies the image, removes the metadata fields it can, and marks the core with `Core::setMetaStripped()`. The encoders read that mark and pass `keep => ForeignKeep::ICC` to the save, which is the only place the block can be kept out. The mark survives `setNative()`, so it still reaches the encoder after any later modifier.

The `copy()` plus `setNative()` is deliberate. A clone shares its vips image, so removing the fields in place would empty both. And `setNative()` clears the stashed source, otherwise a later resize reloads the original file through `thumbnail()` and puts the fields back.

The `keep` and `strip` block was the same in seven encoders, it moves to `src/Traits/CanStripMeta.php`. `PngEncoder` and `GifEncoder` use it too, they passed no `keep` at all before.

After a strip, JPEG, PNG, WEBP and AVIF come out with no profile at all. ICC is kept, animations keep their frames, delays and loop count, and without a strip nothing changes.

Worth flagging:

- `Config::$strip` now applies to PNG and GIF, those two ignored it before. Tell me if you would rather keep them out of it.
- `TiffEncoder`'s pre-8.15 branch passed a literal `strip => true` instead of the resolved value, the shared helper settles that. I noticed it in #103 and left it then.
- `PngEncoder` now reads the driver config, so it needs `setDriver()` when it is instantiated directly. Nothing changes through `Image::encode()`.
- `Frame::toImage()` builds a new core and loses the mark, so the synthesised block comes back there. Documented on `Core::setMetaStripped()`, not fixed.
