### PR TITLE
fix(modifiers): remove the profile without mutating the shared image

### DIFF
--- a/src/Modifiers/RemoveProfileModifier.php
+++ b/src/Modifiers/RemoveProfileModifier.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Modifiers;
 
+use Intervention\Image\Exceptions\DriverException;
+use Intervention\Image\Exceptions\ModifierException;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SpecializedInterface;
 use Intervention\Image\Modifiers\RemoveProfileModifier as GenericRemoveProfileModifier;
@@ -15,14 +17,34 @@ class RemoveProfileModifier extends GenericRemoveProfileModifier implements Spec
      * {@inheritdoc}
      *
      * @see Intervention\Image\Interfaces\ModifierInterface::apply()
+     *
+     * @throws ModifierException
+     * @throws DriverException
      */
     public function apply(ImageInterface $image): ImageInterface
     {
-        try {
-            $image->core()->native()->remove('icc-profile-data');
-        } catch (VipsException) {
-            //
+        $core = $image->core();
+
+        // an image without a profile is left alone. libvips' remove() throws on
+        // a field that is not there, so this is what keeps the call below safe
+        if (!in_array('icc-profile-data', $core->native()->getFields())) {
+            return $image;
         }
+
+        try {
+            // work on a copy, the vips image is shared with any clone of the
+            // image and removing the field in place would strip both
+            $native = $core->native()->copy();
+            $native->remove('icc-profile-data');
+        } catch (VipsException $e) {
+            throw new ModifierException('Failed to remove profile from image', previous: $e);
+        }
+
+        // this also clears the stashed source, which matters. Left in place, a
+        // later resize would reload the original file and bring the profile
+        // back. It costs the shrink on load path though, so removing the
+        // profile before a resize is markedly slower than doing it after.
+        $core->setNative($native);
 
         return $image;
     }

--- a/tests/Unit/Modifiers/RemoveProfileModifierTest.php
+++ b/tests/Unit/Modifiers/RemoveProfileModifierTest.php
@@ -4,11 +4,17 @@ declare(strict_types=1);
 
 namespace Intervention\Image\Drivers\Vips\Tests\Unit\Modifiers;
 
+use Intervention\Image\Drivers\Vips\Core;
 use Intervention\Image\Drivers\Vips\Modifiers\RemoveProfileModifier;
 use Intervention\Image\Drivers\Vips\Tests\BaseTestCase;
 use Intervention\Image\Exceptions\AnalyzerException;
+use Intervention\Image\Format;
+use Intervention\Image\Interfaces\ImageInterface;
+use Jcupitt\Vips\Image as VipsImage;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-class RemoveProfileModifierTest extends BaseTestCase
+#[CoversClass(RemoveProfileModifier::class)]
+final class RemoveProfileModifierTest extends BaseTestCase
 {
     public function testApply(): void
     {
@@ -16,5 +22,85 @@ class RemoveProfileModifierTest extends BaseTestCase
         $image->modify(new RemoveProfileModifier());
         $this->expectException(AnalyzerException::class);
         $image->profile();
+    }
+
+    public function testApplyLeavesNoProfileInEncodedResult(): void
+    {
+        $image = $this->readTestImage('icc.jpg');
+        $image->modify(new RemoveProfileModifier());
+
+        $this->assertNotContains('icc-profile-data', $this->encodedFields($image));
+    }
+
+    /**
+     * An image with no profile must be left strictly alone, it should not pay
+     * for a copy nor lose its stashed source.
+     */
+    public function testApplyWithoutProfileIsANoop(): void
+    {
+        $image = $this->readTestImage('exif.jpg');
+        $core = $image->core();
+        $this->assertInstanceOf(Core::class, $core);
+        $this->assertNotContains('icc-profile-data', $core->native()->getFields());
+
+        $native = $core->native();
+        $stash = $core->stashedSource();
+        $this->assertNotNull($stash);
+
+        $image->modify(new RemoveProfileModifier());
+
+        $this->assertSame($native, $core->native());
+        $this->assertSame($stash, $core->stashedSource());
+    }
+
+    /**
+     * The removal must not leave the decoder's source ref stashed on the core.
+     * A resize served from that ref reloads the original file, which brings the
+     * profile straight back.
+     */
+    public function testRemovedProfileStaysRemovedAfterLaterModifiers(): void
+    {
+        $image = $this->readTestImage('icc.jpg');
+        $core = $image->core();
+        $this->assertInstanceOf(Core::class, $core);
+        $this->assertNotNull($core->stashedSource());
+
+        $image->modify(new RemoveProfileModifier());
+
+        // assert the stash directly, going through resize() alone would stop
+        // testing anything the day the resize fast path changes
+        $this->assertNull($core->stashedSource());
+
+        $image->resize(20, 20);
+
+        $this->assertNotContains('icc-profile-data', $core->native()->getFields());
+        $this->assertNotContains('icc-profile-data', $this->encodedFields($image));
+    }
+
+    /**
+     * A clone shares its vips image with the original, so the removal has to
+     * work on a copy. Removing the field in place would strip both.
+     */
+    public function testApplyOnCloneLeavesTheOriginalUntouched(): void
+    {
+        $image = $this->readTestImage('icc.jpg');
+        $clone = clone $image;
+        $clone->modify(new RemoveProfileModifier());
+
+        $this->assertNotContains('icc-profile-data', $clone->core()->native()->getFields());
+        $this->assertContains('icc-profile-data', $image->core()->native()->getFields());
+        $this->assertContains('icc-profile-data', $this->encodedFields($image));
+    }
+
+    /**
+     * Read back the header field names of the given image encoded as JPEG.
+     *
+     * @return list<string>
+     */
+    private function encodedFields(ImageInterface $image): array
+    {
+        return VipsImage::newFromBuffer(
+            (string) $image->encodeUsingFormat(format: Format::JPEG),
+        )->getFields();
     }
 }


### PR DESCRIPTION
`RemoveProfileModifier` removes `icc-profile-data` straight off the vips image and never calls `setNative()`. It is the only modifier in this driver that mutates the shared native in place instead of handing a new one over, and it has two consequences.

The core keeps the source ref the decoder stashed on it, so a later resize goes through the combined load and resize op and reloads the original file. The profile comes back, on the image and in the encoded output:

```php
$image = $manager->read('icc.jpg');
$image->removeProfile();   // gone
$image->resize(20, 20);    // back, and it ends up in the encoded result
```

And `Image::__clone` clones the core but not the vips image behind it, so both point at the same one. Removing the field in place strips the original too:

```php
$clone = clone $image;
$clone->removeProfile();   // the original loses its profile as well
```

So copy the image, remove the field on the copy, and hand it over with `setNative()`, which clears the stash. An image carrying no profile returns early, which also keeps the remove call safe, libvips throws on a field that is not there.

One thing to know about. `setNative()` clears the source ref the decoder stashed on the core, and that ref is what `resize()` and `cover()` use for shrink on load. So a resize following a `removeProfile()` now decodes the source at full size. On a 4000px JPEG down to 200px:

```
develop      removeProfile -> resize    6.9 ms   profile in output: yes
this branch  removeProfile -> resize   88.2 ms   profile in output: no
this branch  resize -> removeProfile    6.2 ms   profile in output: no
```

develop is not faster, it is fast because it does not do the job, those 6.9 ms return an image that still carries its profile. So at equal output there is no regression, the choice is between 88 ms and 6 ms depending on call order, and the natural order is already the cheap one. The overhead scales with the source, 1.5x at 500px and 14x at 4000px.

The alternative is to keep the stash and teach the resize path to reapply the removal after the reload, with a flag on the core like the one in #123. That would keep both, at the cost of `ResizeModifier` and `CoverModifier` having to know about profile removal. Tell me if you would rather have that.

Three tests added, two of them pin one symptom each and fail on the current implementation.

No overlap with #123, different file, and it needs nothing from it. libvips does not synthesise an ICC profile at save time the way it does for EXIF, so no `keep` flag is involved here.
