### PR TITLE
fix(core): report 0 loops for a still image

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -386,6 +386,12 @@ class Core implements CoreInterface, Iterator
     public function loops(): int
     {
         try {
+            // an image decoded from a still source carries no loop field, GD
+            // and Imagick report 0 there
+            if ($this->vipsImage->getType('loop') === 0) {
+                return 0;
+            }
+
             return (int) $this->vipsImage->get('loop');
         } catch (VipsException $e) {
             throw new DriverException('Failed to load loop count', previous: $e);

--- a/tests/Unit/CoreTest.php
+++ b/tests/Unit/CoreTest.php
@@ -94,6 +94,34 @@ class CoreTest extends BaseTestCase
         $this->assertInstanceOf(Core::class, $result);
     }
 
+    /**
+     * A still image carries no loop field. GD and Imagick report 0 there,
+     * so does this core.
+     */
+    public function testLoopsIsZeroForAStillImage(): void
+    {
+        $core = new Core($this->vipsImage(10, 10, [255, 0, 0]));
+
+        $this->assertSame(0, $core->loops());
+    }
+
+    public function testImageLoopsIsZeroForAStillImage(): void
+    {
+        $this->assertSame(0, $this->readTestImage('test.jpg')->loops());
+        $this->assertSame(0, ImageManager::usingDriver(Driver::class)->createImage(10, 10)->loops());
+    }
+
+    /**
+     * The field is absent until set, the guard must not shadow the value
+     * once it is there.
+     */
+    public function testSetLoopsOnAStillImageThenGet(): void
+    {
+        $core = new Core($this->vipsImage(10, 10, [255, 0, 0]));
+
+        $this->assertSame(7, $core->setLoops(7)->loops());
+    }
+
     public function testHas(): void
     {
         $this->assertTrue($this->core->has(0));


### PR DESCRIPTION
`$image->loops()` on a still image throws with the vips driver:

```php
$manager = new ImageManager(new Driver());
$manager->decodePath('photo.jpg')->loops(); // DriverException, vips_image_get: field "loop" not found
$manager->createImage(10, 10)->loops();     // same
```

GD returns 0 (its default), Imagick returns `getImageIterations()`, 0 for a still image. The vips `Core::loops()` read the `loop` field unguarded. It now checks the field first and returns 0 when it is missing, like `count()` does for `n-pages`.
