### PR TITLE
fix(frame): keep the offset on the frame

### DIFF
--- a/src/Frame.php
+++ b/src/Frame.php
@@ -16,6 +16,17 @@ use Jcupitt\Vips\Image as VipsImage;
 class Frame implements FrameInterface
 {
     /**
+     * The offset is kept on the frame, as the GD driver does, not on the
+     * vips image. libvips has xoffset and yoffset header properties, but
+     * they are pipeline bookkeeping: crop, extract_area, flip or rotate
+     * overwrite them with values of their own, and no encoder writes them
+     * out. Nothing in the driver reads the offset either, it is reported
+     * as set.
+     */
+    protected int $offsetLeft = 0;
+    protected int $offsetTop = 0;
+
+    /**
      * Create new frame instance
      *
      * @return void
@@ -133,8 +144,8 @@ class Frame implements FrameInterface
      */
     public function setOffset(int $left, int $top): FrameInterface
     {
-        $this->setOffsetLeft($left);
-        $this->setOffsetTop($top);
+        $this->offsetLeft = $left;
+        $this->offsetTop = $top;
 
         return $this;
     }
@@ -146,7 +157,7 @@ class Frame implements FrameInterface
      */
     public function offsetLeft(): int
     {
-        return $this->native()->get('xoffset');
+        return $this->offsetLeft;
     }
 
     /**
@@ -156,7 +167,7 @@ class Frame implements FrameInterface
      */
     public function setOffsetLeft(int $offset): FrameInterface
     {
-        $this->native()->set('xoffset', $offset);
+        $this->offsetLeft = $offset;
 
         return $this;
     }
@@ -168,7 +179,7 @@ class Frame implements FrameInterface
      */
     public function offsetTop(): int
     {
-        return $this->native()->get('yoffset');
+        return $this->offsetTop;
     }
 
     /**
@@ -178,7 +189,7 @@ class Frame implements FrameInterface
      */
     public function setOffsetTop(int $offset): FrameInterface
     {
-        $this->native()->set('yoffset', $offset);
+        $this->offsetTop = $offset;
 
         return $this;
     }

--- a/tests/Unit/CoreTest.php
+++ b/tests/Unit/CoreTest.php
@@ -132,6 +132,17 @@ class CoreTest extends BaseTestCase
         }
     }
 
+    /**
+     * frame() extracts with extract_area(), which records the extract origin
+     * in the vips image's yoffset. That is not the frame's offset, GD and
+     * Imagick report 0 here.
+     */
+    public function testFrameOffsetIsZero(): void
+    {
+        $this->assertSame(0, $this->core->frame(1)->offsetLeft());
+        $this->assertSame(0, $this->core->frame(1)->offsetTop());
+    }
+
     public function testFrameDelay(): void
     {
         $this->assertEquals(0.3, $this->core->frame(0)->delay());

--- a/tests/Unit/FrameTest.php
+++ b/tests/Unit/FrameTest.php
@@ -63,4 +63,36 @@ final class FrameTest extends TestCase
     {
         $this->assertEquals(12, $this->testFrame()->setDelay(12)->delay());
     }
+
+    public function testOffsetIsZeroByDefault(): void
+    {
+        $frame = $this->testFrame();
+
+        $this->assertSame(0, $frame->offsetLeft());
+        $this->assertSame(0, $frame->offsetTop());
+    }
+
+    public function testSetOffsetThenGet(): void
+    {
+        $frame = $this->testFrame()->setOffset(11, 22);
+
+        $this->assertSame(11, $frame->offsetLeft());
+        $this->assertSame(22, $frame->offsetTop());
+    }
+
+    /**
+     * The offset lives on the frame. The vips image is left alone, for a
+     * single-frame core it is the core's own. Distinct dimensions on purpose,
+     * libvips hands the same image back for identical black() calls.
+     */
+    public function testSetOffsetLeavesTheVipsImageUntouched(): void
+    {
+        $vipsImage = VipsImage::black(5, 4);
+        $frame = new Frame($vipsImage);
+        $fields = $vipsImage->getFields();
+
+        $frame->setOffset(11, 22);
+
+        $this->assertSame($fields, $vipsImage->getFields());
+    }
 }


### PR DESCRIPTION
`Frame::setOffset()` has no effect with the vips driver, and `offsetTop()` reports the extract origin on animations:

```php
$frame = $image->core()->frame(0);
$frame->setOffset(11, 22);
$frame->offsetLeft(); // 0

$image->core()->frame(1)->offsetTop(); // -15 on a 20x15 animation, GD and Imagick say 0
```

`setOffsetLeft()` and `setOffsetTop()` used `set('xoffset', ...)`, which stores a meta item of that name. `xoffset` and `yoffset` are header properties, and `get()` reads the property first, so the meta item is never seen. The write also went to the vips image in place, and for a single-frame core `frame()` hands out the core's own image.

The header properties are no home for the offset anyway. They are libvips pipeline bookkeeping: `crop`, `extract_area`, `flip` or `rotate` overwrite them with values of their own, which is where the `-15` comes from (`Core::frame()` extracts with `extract_area()`), and no encoder writes them out. The offset now lives on the frame as two properties, like the GD driver does, and the vips image is left alone. Nothing in the driver reads frame offsets, so this only changes what the public getters report.
