### PR TITLE
perf(core): render the pipeline into memory once

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -198,12 +198,7 @@ class Core implements CoreInterface, Iterator
         $this->stashedSource = null;
 
         if (++$this->chainedOperations >= static::MAX_CHAINED_OPERATIONS) {
-            try {
-                $this->vipsImage = $this->vipsImage->copyMemory();
-            } catch (VipsException $e) {
-                throw new DriverException('Failed to render image pipeline into memory', previous: $e);
-            }
-
+            $this->vipsImage = self::renderToMemory($this->vipsImage);
             $this->chainedOperations = 0;
         }
 
@@ -269,15 +264,17 @@ class Core implements CoreInterface, Iterator
      */
     public static function ensureInMemory(CoreInterface $core): CoreInterface
     {
-        if (!in_array('vips-sequential', $core->native()->getFields())) {
-            return $core;
+        $native = $core->native();
+
+        if (!$native instanceof VipsImage) {
+            throw new DriverException(
+                'Failed to render image pipeline into memory, core is not backed by ' . VipsImage::class,
+            );
         }
 
-        if (false === (bool) $core->native()->get('vips-sequential')) {
-            return $core;
+        if (self::isSequential($native)) {
+            $core->setNative(self::renderToMemory($native));
         }
-
-        $core->setNative($core->native()->copyMemory());
 
         return $core;
     }
@@ -334,11 +331,8 @@ class Core implements CoreInterface, Iterator
         }
 
         try {
-            $sequential = in_array('vips-sequential', $this->vipsImage->getFields()) ?
-                $this->vipsImage->get('vips-sequential') : null;
-
-            if ($sequential) {
-                $this->vipsImage = $this->vipsImage->copyMemory();
+            if (self::isSequential($this->vipsImage)) {
+                $this->vipsImage = self::renderToMemory($this->vipsImage);
             }
 
             $delay = in_array('delay', $this->vipsImage->getFields()) ?
@@ -646,6 +640,57 @@ class Core implements CoreInterface, Iterator
         } catch (VipsException $e) {
             throw new DriverException('Failed to reopen the image source for the clone', previous: $e);
         }
+    }
+
+    /**
+     * Whether the given vips image still has to be read in a single
+     * sequential pass, the way the decoders load it.
+     *
+     * @throws DriverException
+     */
+    private static function isSequential(VipsImage $vipsImage): bool
+    {
+        if ($vipsImage->getType('vips-sequential') === 0) {
+            return false;
+        }
+
+        try {
+            return (bool) $vipsImage->get('vips-sequential');
+        } catch (VipsException $e) {
+            throw new DriverException('Failed to read the sequential flag of the image', previous: $e);
+        }
+    }
+
+    /**
+     * Render the pipeline behind the given vips image into memory and drop
+     * the sequential claim from the result.
+     *
+     * The rendered image carries the vips-sequential field of its source
+     * along. That is a stale claim on an image that serves any request from
+     * memory. Left in place, the next check renders the image all over again
+     * and every operation chained on top inherits it. The field is removed
+     * from a copy of the header, never from the rendered image itself:
+     * copyMemory() hands the source back as it is when that one is already
+     * in memory, and it may be shared.
+     *
+     * @throws DriverException
+     */
+    private static function renderToMemory(VipsImage $vipsImage): VipsImage
+    {
+        try {
+            $rendered = $vipsImage->copyMemory();
+
+            if ($rendered->getType('vips-sequential') === 0) {
+                return $rendered;
+            }
+
+            $rendered = $rendered->copy();
+            $rendered->remove('vips-sequential');
+        } catch (VipsException $e) {
+            throw new DriverException('Failed to render image pipeline into memory', previous: $e);
+        }
+
+        return $rendered;
     }
 
     /**

--- a/tests/Unit/CoreTest.php
+++ b/tests/Unit/CoreTest.php
@@ -15,6 +15,7 @@ use Intervention\Image\Exceptions\DriverException;
 use Intervention\Image\Exceptions\InvalidArgumentException;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Interfaces\AnimationFactoryInterface;
+use Intervention\Image\Interfaces\CoreInterface;
 use Intervention\Image\Interfaces\FrameInterface;
 use Jcupitt\Vips\Config;
 use Jcupitt\Vips\BandFormat;
@@ -601,6 +602,72 @@ class CoreTest extends BaseTestCase
 
         $this->assertSame(3, $area->get('n-pages'));
         $this->assertSame([300, 300, 300], $area->get('delay'));
+    }
+
+    /**
+     * The rendered image inherits the sequential claim of its source. Left
+     * there, the next check renders the image all over again.
+     */
+    public function testEnsureInMemoryDropsTheSequentialClaimOnceRendered(): void
+    {
+        $core = $this->readTestImage('test.jpg')->core();
+        $this->assertInstanceOf(Core::class, $core);
+        $this->assertNotSame(0, $core->native()->getType('vips-sequential'));
+
+        Core::ensureInMemory($core);
+        $rendered = $core->native();
+
+        $this->assertSame(0, $rendered->getType('vips-sequential'));
+        Core::ensureInMemory($core);
+        $this->assertSame($rendered, $core->native());
+    }
+
+    /**
+     * An operation chained on a rendered image inherits its fields. With the
+     * claim gone, the chain is left lazy instead of being rendered again.
+     */
+    public function testEnsureInMemoryDoesNotRenderAgainAfterAnOperation(): void
+    {
+        $core = $this->readTestImage('test.jpg')->core();
+        $this->assertInstanceOf(Core::class, $core);
+        Core::ensureInMemory($core);
+
+        $core->setNative($core->native()->flip('horizontal'));
+        $flipped = $core->native();
+        Core::ensureInMemory($core);
+
+        $this->assertSame(0, $flipped->getType('vips-sequential'));
+        $this->assertSame($flipped, $core->native());
+    }
+
+    public function testEnsureInMemoryLeavesAnImageWithoutSequentialClaimAlone(): void
+    {
+        $core = new Core($this->vipsImage(10, 10, [255, 0, 0]));
+        $native = $core->native();
+
+        Core::ensureInMemory($core);
+
+        $this->assertSame($native, $core->native());
+    }
+
+    public function testEnsureInMemoryRejectsACoreWithoutVipsImage(): void
+    {
+        $core = $this->createStub(CoreInterface::class);
+        $core->method('native')->willReturn('not a vips image');
+
+        $this->expectException(DriverException::class);
+        Core::ensureInMemory($core);
+    }
+
+    public function testFrameDropsTheSequentialClaimOnceRendered(): void
+    {
+        $core = $this->readTestImage('animation.gif')->core();
+        $this->assertInstanceOf(Core::class, $core);
+        $this->assertNotSame(0, $core->native()->getType('vips-sequential'));
+
+        $core->frame(0);
+
+        $this->assertSame(0, $core->native()->getType('vips-sequential'));
     }
 
     /**


### PR DESCRIPTION
`copyMemory()` carries the `vips-sequential` field of its source along, so the rendered image still claims to be sequential, and so does every operation chained on top of it. Each `Core::ensureInMemory()` call rendered again, and each time it rendered the whole chain built since the last one. Measured on a 4000x3000 JPEG, `flip()` then `rotate(31)` then `colorAt()`, median of 5 runs:

```
develop  77.8 ms
branch   12.9 ms
```

The three places that render (`setNative()` at the operation limit, `ensureInMemory()`, `frame()`) now go through one helper that drops the stale field from the result. It does so on a `copy()` of the header, not on the rendered image itself: `copyMemory()` hands its source back as it is when that one is already in memory, and that image may be shared. Two `copy()` calls give two distinct images, so the copy is private.

A memory image serves any request from memory, the field means nothing there. Nothing outside `Core` reads it, and the encoders do not write it out.

Tests check the invariant (the field is gone after a render, an operation chained afterwards does not bring a second render) and that `ensureInMemory()` throws on a core without a vips image instead of failing later.
