### PR TITLE
fix(core): set frame meta data on a private copy of the header

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -47,7 +47,9 @@ class Core implements CoreInterface, Iterator
      *
      * This counts calls, not libvips nodes, so it is a bound rather than a
      * measurement. A modifier that chains several nodes per call spends the
-     * budget faster than one node per call.
+     * budget faster than one node per call. The frame round trip of add()
+     * and slice() is the deepest, four nodes per call: extract_area() and
+     * arrayjoin(), each followed by the header copy their fields go on.
      */
     public const MAX_CHAINED_OPERATIONS = 32;
 
@@ -82,7 +84,11 @@ class Core implements CoreInterface, Iterator
         }
 
         try {
-            $vipsImage = VipsImage::arrayjoin($natives, ['across' => 1]);
+            // the joined image comes out of the libvips operation cache, the
+            // same frames give the same image again. Set the fields on a
+            // private copy of the header, or they reach every core built from
+            // these frames
+            $vipsImage = VipsImage::arrayjoin($natives, ['across' => 1])->copy();
             $vipsImage->set('delay', $delay);
             $vipsImage->set('loop', $loops);
             $vipsImage->set('n-pages', count($frames));
@@ -337,13 +343,15 @@ class Core implements CoreInterface, Iterator
             $height = $this->vipsImage->getType('page-height') === 0 ?
                 $this->vipsImage->height : $this->vipsImage->get('page-height');
 
-            // extract only certain frame
+            // extract only certain frame, on a private copy of the header: the
+            // extracted area comes out of the libvips operation cache and a
+            // later extraction of the same area would get the fields set below
             $vipsImage = $this->vipsImage->extract_area(
                 0,
                 $height * $position,
                 $this->vipsImage->width,
                 $height,
-            );
+            )->copy();
 
             $vipsImage->set('n-pages', 1);
             if (!is_null($delay)) {

--- a/tests/Unit/CoreTest.php
+++ b/tests/Unit/CoreTest.php
@@ -14,6 +14,7 @@ use Intervention\Image\Exceptions\InvalidArgumentException;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Interfaces\AnimationFactoryInterface;
 use Intervention\Image\Interfaces\FrameInterface;
+use Jcupitt\Vips\Config;
 use Jcupitt\Vips\Image as VipsImage;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -283,5 +284,70 @@ class CoreTest extends BaseTestCase
 
         $this->assertColor(255, 0, 0, 255, $image->colorAt(2, 2));
         $this->assertColor(0, 0, 255, 255, $image->colorAt(10, 10));
+    }
+
+    /**
+     * arrayjoin() comes out of the libvips operation cache: the same frames
+     * give the same image again, and the fields set on it would reach every
+     * core built from them.
+     */
+    public function testCreateFromFramesLeavesAnEarlierCoreAlone(): void
+    {
+        $this->pinOperationCache();
+        $frames = [
+            new Frame($this->vipsImage(10, 10, [255, 0, 0]), 0.1),
+            new Frame($this->vipsImage(10, 10, [0, 255, 0]), 0.1),
+        ];
+        $core = Core::createFromFrames($frames, 3);
+
+        $other = Core::createFromFrames($frames, 9);
+
+        $this->assertSame(9, $other->loops());
+        $this->assertSame(3, $core->loops());
+    }
+
+    /**
+     * Same natives, other delays: the frames differ, the arrayjoin() call
+     * does not.
+     */
+    public function testCreateFromFramesWithOtherDelaysLeavesAnEarlierCoreAlone(): void
+    {
+        $this->pinOperationCache();
+        $red = $this->vipsImage(10, 10, [255, 0, 0]);
+        $green = $this->vipsImage(10, 10, [0, 255, 0]);
+        $core = Core::createFromFrames([new Frame($red, 0.1), new Frame($green, 0.1)]);
+
+        $other = Core::createFromFrames([new Frame($red, 0.5), new Frame($green, 0.5)]);
+
+        $this->assertEquals(0.5, $other->frame(0)->delay());
+        $this->assertEquals(0.1, $core->frame(0)->delay());
+    }
+
+    /**
+     * The extracted area comes out of the operation cache too, a later
+     * extraction of the same area would get the fields frame() sets.
+     */
+    public function testFrameLeavesTheExtractedAreaAlone(): void
+    {
+        $this->pinOperationCache();
+        $native = $this->core->native();
+        $height = $native->get('page-height');
+        $this->core->frame(1);
+
+        $area = $native->extract_area(0, $height, $native->width, $height);
+
+        $this->assertSame(3, $area->get('n-pages'));
+        $this->assertSame([300, 300, 300], $area->get('delay'));
+    }
+
+    /**
+     * The tests on the operation cache rely on libvips handing the same
+     * image back for the same call. With the cache switched off they would
+     * pass on the very code they guard. 1000 operations is the libvips
+     * default.
+     */
+    private function pinOperationCache(): void
+    {
+        Config::cacheSetMax(1000);
     }
 }


### PR DESCRIPTION
libvips caches operations, so `arrayjoin()` on the same frames hands the same image back. `Core::createFromFrames()` set `delay`, `loop` and `n-pages` on that image in place, and the fields reached every core built from the same frames:

```php
$a = Core::createFromFrames($frames, 3);
$b = Core::createFromFrames($frames, 9);
$a->loops(); // 9
```

Same with the delays: build an animation from the same natives with other timings and the first one changes too.

`Core::frame()` had the same defect on the output of `extract_area()`: a later extraction of the same area came back with the `n-pages` and `delay` of a single frame.

Both now `copy()` the operation output before setting the fields, which is the pattern of #123 and #124 (`copy()` is not cached, two calls give two images). The copy is a header copy, no pixels involved.
